### PR TITLE
ci: run integration tests on a GitHub-hosted runner

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -117,10 +117,22 @@ jobs:
 
   integration-test:
     name: Integration Test
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
+    env:
+      MLIR_SYS_190_PREFIX: /usr/lib/llvm-19
+      LLVM_SYS_191_PREFIX: /usr/lib/llvm-19
+      TABLEGEN_190_PREFIX: /usr/lib/llvm-19
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+
+      - name: Install LLVM 19 (required for cairo_native)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            llvm-19 llvm-19-dev llvm-19-runtime \
+            clang-19 clang-tools-19 lld-19 \
+            libpolly-19-dev libmlir-19-dev mlir-19-tools
 
       - name: Load common configuration
         id: config
@@ -130,6 +142,14 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ steps.config.outputs.rust_stable_version }}
+
+      - name: Cache cargo registry & build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            . -> target
+            tests/integration -> tests/integration/target
+          shared-key: ${{ runner.os }}-integration-test
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1.8.0

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -148,8 +148,9 @@ jobs:
         with:
           workspaces: |
             . -> target
-            tests/integration -> tests/integration/target
+            tests/integration
           shared-key: ${{ runner.os }}-integration-test
+          add-rust-environment-hash-key: "false"
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1.8.0


### PR DESCRIPTION
## Development related changes

Moves the `integration-test` job from a self-hosted runner to a GitHub-hosted `ubuntu-latest` runner.

Changes in `.github/workflows/build-and-test.yml`:
- `runs-on: self-hosted` → `runs-on: ubuntu-latest`
- Add LLVM 19 `apt-get` install step (the workspace's `cairo_native` dep needs it)
- Add `MLIR_SYS_190_PREFIX` / `LLVM_SYS_191_PREFIX` / `TABLEGEN_190_PREFIX` env vars
- Add `Swatinem/rust-cache@v2` scoped to root + `tests/integration` with a distinct key, to keep cold `cargo build --release` times reasonable on hosted runners

## Checklist:

- [x] Checked out the [contribution guidelines](https://github.com/starknet-io/starknet-devnet/blob/main/.github/CONTRIBUTING.md)
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [ ] Applied formatting - `./scripts/format.sh`
- [ ] No linter errors - `./scripts/clippy_check.sh`
- [ ] No unused dependencies - `./scripts/check_unused_deps.sh`
- [ ] No spelling errors - `./scripts/check_spelling.sh`
- [ ] Updated the docs if needed - `./website/README.md`
- [ ] Linked the [issues](https://github.com/starknet-io/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] Updated the tests if needed; all passing - [execution info](https://github.com/starknet-io/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)