### PR TITLE
Support inline dump and load events

### DIFF
--- a/crates/starknet-devnet-server/src/api/json_rpc_handler.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc_handler.rs
@@ -648,6 +648,7 @@ impl JsonRpcHandler {
                     let msg = format!("Failed dumping of {}: {e}", event.method);
                     RpcError::internal_error_with(msg)
                 })?;
+                self.api.dumpable_events.lock().await.push(event.clone());
             }
             Some(DumpOn::Request | DumpOn::Exit) => {
                 self.api.dumpable_events.lock().await.push(event.clone())

--- a/crates/starknet-devnet-server/src/api/json_rpc_handler.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc_handler.rs
@@ -643,12 +643,13 @@ impl JsonRpcHandler {
                     .dump_path
                     .as_deref()
                     .ok_or(RpcError::internal_error_with("Undefined dump path"))?;
+                let mut dumpable_events = self.api.dumpable_events.lock().await;
 
                 dump_event(event, path).map_err(|e| {
                     let msg = format!("Failed dumping of {}: {e}", event.method);
                     RpcError::internal_error_with(msg)
                 })?;
-                self.api.dumpable_events.lock().await.push(event.clone());
+                dumpable_events.push(event.clone());
             }
             Some(DumpOn::Request | DumpOn::Exit) => {
                 self.api.dumpable_events.lock().await.push(event.clone())

--- a/crates/starknet-devnet-server/src/api/json_rpc_handler.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc_handler.rs
@@ -18,9 +18,9 @@ use crate::api::models::{
     BroadcastedDeployAccountTransactionInput, BroadcastedInvokeTransactionEnumWrapper,
     BroadcastedInvokeTransactionInput, CallInput, ClassHashInput, DevnetSpecRequest,
     EstimateFeeInput, EventsInput, GetStorageInput, JsonRpcRequest, JsonRpcResponse,
-    JsonRpcWsRequest, LoadPath, ProveTransactionInput, SimulateTransactionsInput,
-    StarknetSpecExtRequest, StarknetSpecRequest, StateUpdateInput, ToRpcResponseResult,
-    TransactionHashAndFlagsInput, TransactionHashInput, to_json_rpc_request,
+    JsonRpcWsRequest, ProveTransactionInput, SimulateTransactionsInput, StarknetSpecExtRequest,
+    StarknetSpecRequest, StateUpdateInput, ToRpcResponseResult, TransactionHashAndFlagsInput,
+    TransactionHashInput, to_json_rpc_request,
 };
 use crate::api::origin_forwarder::OriginForwarder;
 use crate::api::{Api, ApiError, error};
@@ -524,8 +524,8 @@ impl JsonRpcHandler {
             }
             DevnetSpecRequest::AutoImpersonate => self.set_auto_impersonate(true).await,
             DevnetSpecRequest::StopAutoImpersonate => self.set_auto_impersonate(false).await,
-            DevnetSpecRequest::Dump(path) => self.dump(path).await,
-            DevnetSpecRequest::Load(LoadPath { path }) => self.load(path).await,
+            DevnetSpecRequest::Dump(request) => self.dump(request.unwrap_or_default()).await,
+            DevnetSpecRequest::Load(request) => self.load(request).await,
             DevnetSpecRequest::PostmanLoadL1MessagingContract(data) => {
                 self.postman_load(data).await
             }
@@ -637,14 +637,14 @@ impl JsonRpcHandler {
     async fn update_dump(&self, event: &RpcMethodCall) -> Result<(), RpcError> {
         match self.api.config.dump_on {
             Some(DumpOn::Block) => {
-                let dump_path = self
+                let path = self
                     .api
                     .config
                     .dump_path
                     .as_deref()
-                    .ok_or(RpcError::internal_error_with("Undefined dump_path"))?;
+                    .ok_or(RpcError::internal_error_with("Undefined dump path"))?;
 
-                dump_event(event, dump_path).map_err(|e| {
+                dump_event(event, path).map_err(|e| {
                     let msg = format!("Failed dumping of {}: {e}", event.method);
                     RpcError::internal_error_with(msg)
                 })?;

--- a/crates/starknet-devnet-server/src/api/models/json_rpc_request.rs
+++ b/crates/starknet-devnet-server/src/api/models/json_rpc_request.rs
@@ -14,9 +14,9 @@ use crate::api::models::{
     BlockAndContractAddressInput, BlockAndIndexInput, BlockIdAndFlagsInput, BlockIdInput,
     BlockTransactionTracesInput, BroadcastedDeclareTransactionInput,
     BroadcastedDeployAccountTransactionInput, BroadcastedInvokeTransactionInput, CallInput,
-    ClassHashInput, DumpPath, EstimateFeeInput, EventsInput, EventsSubscriptionInput,
+    ClassHashInput, DumpRequest, EstimateFeeInput, EventsInput, EventsSubscriptionInput,
     FlushParameters, GetStorageInput, GetStorageProofInput, IncreaseTime, JsonRpcResponse,
-    L1TransactionHashInput, LoadPath, MintTokensRequest, PostmanLoadL1MessagingContract,
+    L1TransactionHashInput, LoadRequest, MintTokensRequest, PostmanLoadL1MessagingContract,
     ProveTransactionInput, RestartParameters, SetTime, SimulateTransactionsInput, StateUpdateInput,
     SubscriptionBlockIdInput, SubscriptionIdInput, TransactionHashAndFlagsInput,
     TransactionHashInput, TransactionReceiptSubscriptionInput, TransactionSubscriptionInput,
@@ -148,9 +148,9 @@ pub enum DevnetSpecRequest {
     #[serde(rename = "devnet_stopAutoImpersonate", with = "empty_params")]
     StopAutoImpersonate,
     #[serde(rename = "devnet_dump", with = "optional_params")]
-    Dump(Option<DumpPath>),
+    Dump(Option<DumpRequest>),
     #[serde(rename = "devnet_load")]
-    Load(LoadPath),
+    Load(LoadRequest),
     #[serde(rename = "devnet_postmanLoad")]
     PostmanLoadL1MessagingContract(PostmanLoadL1MessagingContract),
     #[serde(rename = "devnet_postmanFlush", with = "optional_params")]

--- a/crates/starknet-devnet-server/src/api/models/mod.rs
+++ b/crates/starknet-devnet-server/src/api/models/mod.rs
@@ -367,18 +367,21 @@ pub struct TransactionReceiptSubscriptionInput {
     pub finality_status: Option<Vec<TransactionFinalityStatusWithoutL1>>,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone, Default)]
 #[serde(deny_unknown_fields)]
-#[cfg_attr(test, derive(Debug))]
-pub struct DumpPath {
-    pub path: String,
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+pub struct DumpRequest {
+    pub path: Option<String>,
+    #[serde(default)]
+    pub inline: bool,
 }
 
-#[derive(Deserialize)]
-#[serde(deny_unknown_fields)]
-#[cfg_attr(test, derive(Debug))]
-pub struct LoadPath {
-    pub path: String,
+#[derive(Deserialize, Clone)]
+#[serde(untagged, deny_unknown_fields)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+pub enum LoadRequest {
+    Path { path: String },
+    Events { events: Vec<RpcMethodCall> },
 }
 
 #[derive(Deserialize)]

--- a/crates/starknet-devnet-server/src/api/write_endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/write_endpoints.rs
@@ -128,9 +128,6 @@ impl JsonRpcHandler {
         if !path.is_empty() {
             dump_events(&dumpable_events, &path)
                 .map_err(|err| ApiError::DumpError { msg: err.to_string() })?;
-            if !request.inline {
-                return Ok(DevnetResponse::DevnetDump(None).into());
-            }
         }
 
         Ok(DevnetResponse::DevnetDump(Some(dumpable_events)).into())

--- a/crates/starknet-devnet-server/src/api/write_endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/write_endpoints.rs
@@ -118,7 +118,8 @@ impl JsonRpcHandler {
             });
         }
 
-        let dumpable_events = { self.api.dumpable_events.lock().await.clone() };
+        // Keep the event snapshot and any file rewrite synchronized with block-mode appends.
+        let dumpable_events = self.api.dumpable_events.lock().await;
 
         let path = if request.inline {
             request.path.unwrap_or_default()
@@ -131,11 +132,13 @@ impl JsonRpcHandler {
                 .map_err(|err| ApiError::DumpError { msg: err.to_string() })?;
         }
 
-        Ok(DevnetResponse::DevnetDump(Some(dumpable_events)).into())
+        Ok(DevnetResponse::DevnetDump(Some(dumpable_events.clone())).into())
     }
 
     /// devnet_load
     pub async fn load(&self, request: LoadRequest) -> StrictRpcResult {
+        // Serialize file reads and clears with block-mode appends and endpoint rewrites.
+        let dumpable_events = self.api.dumpable_events.lock().await;
         let events = match request {
             LoadRequest::Path { path } => load_events(self.api.config.dump_on, &path)?,
             LoadRequest::Events { events } => {
@@ -147,6 +150,8 @@ impl JsonRpcHandler {
                 events
             }
         };
+        // Re-execution records the loaded events, so release the lock before restarting.
+        drop(dumpable_events);
 
         // Necessary to restart before loading; restarting messaging to allow re-execution
         self.restart(Some(RestartParameters { restart_l1_to_l2_messaging: true })).await?;

--- a/crates/starknet-devnet-server/src/api/write_endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/write_endpoints.rs
@@ -1,3 +1,4 @@
+use starknet_core::starknet::starknet_config::DumpOn;
 use starknet_rs_core::types::TransactionExecutionStatus;
 use starknet_types::contract_address::ContractAddress;
 use starknet_types::felt::{TransactionHash, felt_from_prefixed_hex};
@@ -24,7 +25,7 @@ use crate::api::models::{
     MessageHash, MessagingLoadAddress, MintTokensRequest, MintTokensResponse,
     PostmanLoadL1MessagingContract, RestartParameters, SetTime, SetTimeResponse,
 };
-use crate::dump_util::{dump_events, load_events};
+use crate::dump_util::{clear_dump_file, dump_events, load_events};
 use crate::rpc_core::error::RpcError;
 use crate::rpc_core::request::RpcMethodCall;
 use crate::rpc_core::response::ResponseResult;
@@ -137,7 +138,14 @@ impl JsonRpcHandler {
     pub async fn load(&self, request: LoadRequest) -> StrictRpcResult {
         let events = match request {
             LoadRequest::Path { path } => load_events(self.api.config.dump_on, &path)?,
-            LoadRequest::Events { events } => events,
+            LoadRequest::Events { events } => {
+                if let (Some(DumpOn::Block), Some(path)) =
+                    (self.api.config.dump_on, self.api.config.dump_path.as_deref())
+                {
+                    clear_dump_file(path)?;
+                }
+                events
+            }
         };
 
         // Necessary to restart before loading; restarting messaging to allow re-execution

--- a/crates/starknet-devnet-server/src/api/write_endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/write_endpoints.rs
@@ -19,10 +19,10 @@ use super::models::{
 use crate::api::JsonRpcHandler;
 use crate::api::account_helpers::{get_balance, get_erc20_fee_unit_address};
 use crate::api::models::{
-    AbortedBlocks, AbortingBlocks, AcceptOnL1Request, AcceptedOnL1Blocks, CreatedBlock, DumpPath,
-    FlushParameters, FlushedMessages, IncreaseTime, IncreaseTimeResponse, MessageHash,
-    MessagingLoadAddress, MintTokensRequest, MintTokensResponse, PostmanLoadL1MessagingContract,
-    RestartParameters, SetTime, SetTimeResponse,
+    AbortedBlocks, AbortingBlocks, AcceptOnL1Request, AcceptedOnL1Blocks, CreatedBlock,
+    DumpRequest, FlushParameters, FlushedMessages, IncreaseTime, IncreaseTimeResponse, LoadRequest,
+    MessageHash, MessagingLoadAddress, MintTokensRequest, MintTokensResponse,
+    PostmanLoadL1MessagingContract, RestartParameters, SetTime, SetTimeResponse,
 };
 use crate::dump_util::{dump_events, load_events};
 use crate::rpc_core::error::RpcError;
@@ -110,33 +110,39 @@ impl JsonRpcHandler {
     }
 
     /// devnet_dump
-    pub async fn dump(&self, path: Option<DumpPath>) -> StrictRpcResult {
+    pub async fn dump(&self, request: DumpRequest) -> StrictRpcResult {
         if self.api.config.dump_on.is_none() {
             return Err(ApiError::DumpError {
                 msg: "Please provide --dump-on mode on startup.".to_string(),
             });
         }
 
-        let path = path
-            .as_ref()
-            .map(|DumpPath { path }| path.clone())
-            .or_else(|| self.api.config.dump_path.clone())
-            .unwrap_or_default();
-
         let dumpable_events = { self.api.dumpable_events.lock().await.clone() };
+
+        let path = if request.inline {
+            request.path.unwrap_or_default()
+        } else {
+            request.path.or_else(|| self.api.config.dump_path.clone()).unwrap_or_default()
+        };
 
         if !path.is_empty() {
             dump_events(&dumpable_events, &path)
                 .map_err(|err| ApiError::DumpError { msg: err.to_string() })?;
-            return Ok(DevnetResponse::DevnetDump(None).into());
+            if !request.inline {
+                return Ok(DevnetResponse::DevnetDump(None).into());
+            }
         }
 
         Ok(DevnetResponse::DevnetDump(Some(dumpable_events)).into())
     }
 
     /// devnet_load
-    pub async fn load(&self, path: String) -> StrictRpcResult {
-        let events = load_events(self.api.config.dump_on, &path)?;
+    pub async fn load(&self, request: LoadRequest) -> StrictRpcResult {
+        let events = match request {
+            LoadRequest::Path { path } => load_events(self.api.config.dump_on, &path)?,
+            LoadRequest::Events { events } => events,
+        };
+
         // Necessary to restart before loading; restarting messaging to allow re-execution
         self.restart(Some(RestartParameters { restart_l1_to_l2_messaging: true })).await?;
         self.re_execute(&events).await.map_err(ApiError::RpcError)?;

--- a/crates/starknet-devnet-server/src/dump_util.rs
+++ b/crates/starknet-devnet-server/src/dump_util.rs
@@ -53,6 +53,15 @@ pub fn dump_event(event: &DumpEvent, path: &str) -> DevnetResult<()> {
     Ok(())
 }
 
+/// Removes the dump file at `path`, ignoring it if it does not exist.
+pub fn clear_dump_file(path: &str) -> DevnetResult<()> {
+    match fs::remove_file(Path::new(path)) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(Error::IoError(err)),
+    }
+}
+
 /// Returns Devnet events from the provided `path`
 pub fn load_events(dump_on: Option<DumpOn>, path: &str) -> DevnetResult<Vec<DumpEvent>> {
     let file_path = Path::new(path);
@@ -68,7 +77,7 @@ pub fn load_events(dump_on: Option<DumpOn>, path: &str) -> DevnetResult<Vec<Dump
     // because they will be re-executed and saved again
     if let Some(DumpOn::Block) = dump_on {
         // TODO refactor: this shouldn't be the responsibility of this method
-        fs::remove_file(file_path).map_err(Error::IoError)?;
+        clear_dump_file(path)?;
     }
 
     Ok(events)

--- a/tests/integration/dump_and_load.rs
+++ b/tests/integration/dump_and_load.rs
@@ -385,6 +385,12 @@ async fn dump_endpoint_inline_with_block_mode() {
         .unwrap();
     assert!(Path::new(&custom_dump_file.path).exists());
     assert_eq!(inline_path_dump, inline_dump);
+
+    devnet.send_custom_rpc("devnet_load", json!({ "events": inline_dump.clone() })).await.unwrap();
+
+    let persisted_dump: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&dump_file.path).unwrap()).unwrap();
+    assert_eq!(persisted_dump, inline_dump);
 }
 
 #[tokio::test]

--- a/tests/integration/dump_and_load.rs
+++ b/tests/integration/dump_and_load.rs
@@ -62,18 +62,10 @@ async fn dump_load_dump_load_without_path() {
         devnet_dump.create_block().await.unwrap();
         devnet_dump.mint(DUMMY_ADDRESS, DUMMY_AMOUNT).await;
     }
-    let dump_rpc = devnet_dump.send_custom_rpc("devnet_dump", json!({})).await.unwrap().to_string();
-    let dump_file = UniqueAutoDeletableFile::new("dump_load_dump_load_on_request_nofile");
-    std::fs::write(&dump_file.path, dump_rpc).expect("Failed to write dump file");
+    let dump_rpc = devnet_dump.send_custom_rpc("devnet_dump", json!({})).await.unwrap();
 
-    let devnet_load = BackgroundDevnet::spawn_with_additional_args(&[
-        "--dump-path",
-        &dump_file.path,
-        "--dump-on",
-        "request",
-    ])
-    .await
-    .expect("Could not start Devnet");
+    let devnet_load = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
+    devnet_load.send_custom_rpc("devnet_load", json!({ "events": dump_rpc })).await.unwrap();
 
     let last_block = devnet_load.get_latest_block_with_tx_hashes().await.unwrap();
     assert_eq!(last_block.block_number, 4);
@@ -369,10 +361,36 @@ async fn load_endpoint_fail_with_wrong_path() {
 
 #[tokio::test]
 async fn dump_load_endpoints_transaction_and_state_after_load_is_valid() {
-    // check if the dump with the default path "dump_endpoint" works as expected when json body
-    // is empty, later check if the dump with the custom path "dump_endpoint_custom_path"
-    // works
+    // check if the dump with empty params uses the startup path, later check if the dump with the
+    // custom path "dump_endpoint_custom_path" works
     let dump_file = UniqueAutoDeletableFile::new("dump_endpoint");
+    let inline_dump_file = UniqueAutoDeletableFile::new("dump_endpoint_force_inline");
+    let devnet_inline_dump = BackgroundDevnet::spawn_with_additional_args(&[
+        "--dump-path",
+        &inline_dump_file.path,
+        "--dump-on",
+        "exit",
+    ])
+    .await
+    .expect("Could not start Devnet");
+
+    devnet_inline_dump.mint(DUMMY_ADDRESS, DUMMY_AMOUNT).await;
+    let forced_inline_dump =
+        devnet_inline_dump.send_custom_rpc("devnet_dump", json!({ "inline": true })).await.unwrap();
+    assert!(!Path::new(&inline_dump_file.path).exists());
+    assert!(forced_inline_dump.as_array().is_some_and(|events| !events.is_empty()));
+
+    let inline_path_dump_file = UniqueAutoDeletableFile::new("dump_endpoint_force_inline_path");
+    let forced_inline_path_dump = devnet_inline_dump
+        .send_custom_rpc(
+            "devnet_dump",
+            json!({ "path": inline_path_dump_file.path, "inline": true }),
+        )
+        .await
+        .unwrap();
+    assert!(Path::new(&inline_path_dump_file.path).exists());
+    assert!(forced_inline_path_dump.as_array().is_some_and(|events| !events.is_empty()));
+
     let devnet_dump = BackgroundDevnet::spawn_with_additional_args(&[
         "--dump-path",
         &dump_file.path,
@@ -383,15 +401,17 @@ async fn dump_load_endpoints_transaction_and_state_after_load_is_valid() {
     .expect("Could not start Devnet");
 
     let mint_tx_hash = devnet_dump.mint(DUMMY_ADDRESS, DUMMY_AMOUNT).await;
-    devnet_dump.send_custom_rpc("devnet_dump", json!({})).await.unwrap();
+    let default_path_dump = devnet_dump.send_custom_rpc("devnet_dump", json!({})).await.unwrap();
+    assert_eq!(default_path_dump, serde_json::Value::Null);
     assert!(Path::new(&dump_file.path).exists());
 
     let dump_file_custom = UniqueAutoDeletableFile::new("dump_endpoint_custom_path");
-    devnet_dump
+    let file_dump = devnet_dump
         .send_custom_rpc("devnet_dump", json!({ "path": dump_file_custom.path }))
         .await
         .unwrap();
     assert!(Path::new(&dump_file_custom.path).exists());
+    assert_eq!(file_dump, serde_json::Value::Null);
 
     // load and re-execute from "dump_endpoint" file and check if transaction and state of the
     // blockchain is valid

--- a/tests/integration/dump_and_load.rs
+++ b/tests/integration/dump_and_load.rs
@@ -360,6 +360,34 @@ async fn load_endpoint_fail_with_wrong_path() {
 }
 
 #[tokio::test]
+async fn dump_endpoint_inline_with_block_mode() {
+    let dump_file = UniqueAutoDeletableFile::new("dump_endpoint_inline_block_mode");
+    let devnet = BackgroundDevnet::spawn_with_additional_args(&[
+        "--dump-path",
+        &dump_file.path,
+        "--dump-on",
+        "block",
+    ])
+    .await
+    .expect("Could not start Devnet");
+
+    devnet.mint(DUMMY_ADDRESS, DUMMY_AMOUNT).await;
+
+    let inline_dump =
+        devnet.send_custom_rpc("devnet_dump", json!({ "inline": true })).await.unwrap();
+    assert!(inline_dump.as_array().is_some_and(|events| !events.is_empty()));
+
+    let custom_dump_file =
+        UniqueAutoDeletableFile::new("dump_endpoint_inline_block_mode_custom_path");
+    let inline_path_dump = devnet
+        .send_custom_rpc("devnet_dump", json!({ "path": custom_dump_file.path, "inline": true }))
+        .await
+        .unwrap();
+    assert!(Path::new(&custom_dump_file.path).exists());
+    assert_eq!(inline_path_dump, inline_dump);
+}
+
+#[tokio::test]
 async fn dump_load_endpoints_transaction_and_state_after_load_is_valid() {
     // check if the dump with empty params uses the startup path, later check if the dump with the
     // custom path "dump_endpoint_custom_path" works
@@ -402,7 +430,7 @@ async fn dump_load_endpoints_transaction_and_state_after_load_is_valid() {
 
     let mint_tx_hash = devnet_dump.mint(DUMMY_ADDRESS, DUMMY_AMOUNT).await;
     let default_path_dump = devnet_dump.send_custom_rpc("devnet_dump", json!({})).await.unwrap();
-    assert_eq!(default_path_dump, serde_json::Value::Null);
+    assert!(default_path_dump.as_array().is_some_and(|events| !events.is_empty()));
     assert!(Path::new(&dump_file.path).exists());
 
     let dump_file_custom = UniqueAutoDeletableFile::new("dump_endpoint_custom_path");
@@ -411,7 +439,7 @@ async fn dump_load_endpoints_transaction_and_state_after_load_is_valid() {
         .await
         .unwrap();
     assert!(Path::new(&dump_file_custom.path).exists());
-    assert_eq!(file_dump, serde_json::Value::Null);
+    assert_eq!(file_dump, default_path_dump);
 
     // load and re-execute from "dump_endpoint" file and check if transaction and state of the
     // blockchain is valid

--- a/tests/integration/websocket.rs
+++ b/tests/integration/websocket.rs
@@ -203,7 +203,23 @@ async fn should_load_correct_devnet_with_state_modified_via_ws() {
         )
         .await
         .unwrap();
-        assert_eq!(dump_resp, json!({ "jsonrpc": "2.0", "id": 0, "result": null }));
+        assert_eq!(
+            dump_resp,
+            json!({
+                "jsonrpc": "2.0",
+                "id": 0,
+                "result": [{
+                    "jsonrpc": "2.0",
+                    "method": "devnet_mint",
+                    "params": {
+                        "address": mint_address,
+                        "amount": mint_amount,
+                        "unit": "FRI"
+                    },
+                    "id": 0
+                }]
+            })
+        );
 
         send_ctrl_c_signal_and_wait(&devnet_dumpable.process).await;
     }

--- a/website/docs/dump-load-restart.md
+++ b/website/docs/dump-load-restart.md
@@ -20,13 +20,15 @@ $ starknet-devnet --dump-on block --dump-path <PATH>
 
 ### Dumping on request
 
-You can request dumping via JSON-RPC. An optional file path can be provided in the request or on startup via `--dump-path <FILE>` (the HTTP request parameter takes precedence). If no dumping path is specified, the dump is included in the response body. This means that if you request dumping via [`curl`](https://curl.se/), it will be printed to STDOUT, which you can then redirect to a destination of your choice.
+You can request dumping via JSON-RPC. An optional file path can be provided in the request or on startup via `--dump-path <FILE>` (the JSON-RPC request parameter takes precedence). The dumped events are always included in the response, including when they are also written to a file.
+
+By default, a request without a `path` uses the path supplied through `--dump-path`, if one was configured. Set `inline` to `true` to ignore that startup path and return the events without writing to it. A `path` supplied in the same request is still written to, even when `inline` is `true`.
 
 ```
 $ starknet-devnet --dump-on <MODE> [--dump-path <FILE>]
 ```
 
-- No body parameters:
+- Use the startup path if configured; otherwise return the events without writing a file:
 
 ```
 JSON-RPC
@@ -37,7 +39,7 @@ JSON-RPC
 }
 ```
 
-- With a custom path:
+- Write to a custom path and return the events:
 
 ```
 JSON-RPC
@@ -52,6 +54,20 @@ JSON-RPC
 }
 ```
 
+- Return the events without writing to the startup path:
+
+```
+JSON-RPC
+{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "devnet_dump",
+    "params": {
+        "inline": true
+    }
+}
+```
+
 ## Loading
 
 To load a preserved Devnet instance, the options are:
@@ -62,7 +78,9 @@ To load a preserved Devnet instance, the options are:
 $ starknet-devnet --dump-path <PATH>
 ```
 
-- Loading on request, which replaces the current state with the one in the provided file. It can be done via JSON-RPC:
+- Loading on request, which replaces the current state by re-executing events. Provide either a dump file path or dumped events directly in the request body.
+
+To load from a file:
 
 ```
 JSON-RPC
@@ -75,6 +93,24 @@ JSON-RPC
     }
 }
 ```
+
+To load events directly:
+
+```
+JSON-RPC
+{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "devnet_load",
+    "params": {
+        "events": [
+            // events returned by devnet_dump
+        ]
+    }
+}
+```
+
+The `path` and `events` parameters are mutually exclusive. Passing both, or neither, results in an invalid-params error.
 
 ### Loading disclaimer
 


### PR DESCRIPTION
## Usage related changes

- devnet_dump now returns dumped events even when writing them to a file.
- devnet_load accepts dumped events directly in the request body.
- Block dump mode now supports complete inline and custom-path responses.
- Closes #944.

## Development related changes

- Added request models for inline dump and load payloads.
- Retained block-mode events for later dump responses.
- Added integration coverage for inline loading, file-backed responses, and block-mode inline dumping.

## Checklist:

- [x] Checked out the contribution guidelines
- [x] Applied formatting - ./scripts/format.sh
- [x] No linter errors - ./scripts/clippy_check.sh
- [ ] No unused dependencies - ./scripts/check_unused_deps.sh
  - Reports the pre-existing apollo_compilation_utils dependency in starknet-devnet-types; this PR does not change dependencies.
- [x] No spelling errors - ./scripts/check_spelling.sh
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch
- [ ] Updated the docs if needed
  - No documentation files were changed.
- [x] Linked the issues resolvable by this PR
- [x] Updated the tests if needed; all passing