### PR TITLE
Fix L1 acceptance for fork-origin blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7761,6 +7761,7 @@ dependencies = [
  "futures",
  "http-body-util",
  "lazy_static",
+ "lru 0.16.4",
  "prometheus",
  "rand 0.9.4",
  "rand_chacha 0.9.0",

--- a/crates/starknet-devnet-server/Cargo.toml
+++ b/crates/starknet-devnet-server/Cargo.toml
@@ -34,6 +34,7 @@ thiserror = { workspace = true }
 anyhow = { workspace = true }
 enum-helper-macros = { workspace = true }
 rand = { workspace = true }
+lru = { workspace = true }
 starknet-rs-core = { workspace = true }
 
 # forking

--- a/crates/starknet-devnet-server/src/api/origin_forwarder.rs
+++ b/crates/starknet-devnet-server/src/api/origin_forwarder.rs
@@ -1,18 +1,40 @@
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
+use lru::LruCache;
 use serde_json::json;
 use starknet_rs_core::types::{
-    BlockId as ImportedBlockId, BlockTag as ImportedBlockTag, BlockWithTxHashes,
-    MaybePreConfirmedBlockWithTxHashes,
+    BlockId as ImportedBlockId, BlockStatus as ImportedBlockStatus, BlockTag as ImportedBlockTag,
+    BlockWithTxHashes, Felt, MaybePreConfirmedBlockWithTxHashes,
 };
 use starknet_rs_providers::jsonrpc::HttpTransport;
 use starknet_rs_providers::{JsonRpcClient, Provider};
 use starknet_types::rpc::block::{BlockId, BlockTag};
+use tokio::sync::{Mutex, RwLock};
 
 use super::error::ApiError;
 use crate::rpc_core::error::RpcError;
-use crate::rpc_core::request::RpcMethodCall;
+use crate::rpc_core::request::{RequestParams, RpcMethodCall};
 use crate::rpc_core::response::{ResponseResult, RpcResponse};
+
+const TRANSACTION_BLOCK_NUMBER_CACHE_CAPACITY: usize = 1024;
+
+struct OriginAcceptance {
+    accepted_on_l1_through: Option<u64>,
+    transaction_block_numbers: LruCache<Felt, u64>,
+}
+
+impl Default for OriginAcceptance {
+    fn default() -> Self {
+        Self {
+            accepted_on_l1_through: None,
+            transaction_block_numbers: LruCache::new(
+                NonZeroUsize::new(TRANSACTION_BLOCK_NUMBER_CACHE_CAPACITY)
+                    .unwrap_or(NonZeroUsize::MIN),
+            ),
+        }
+    }
+}
 
 /// Used for forwarding requests to origin in case of:
 /// - BlockNotFound
@@ -27,6 +49,8 @@ pub struct OriginForwarder {
     url: Arc<String>,
     block_number: u64,
     pub(crate) starknet_client: JsonRpcClient<HttpTransport>,
+    acceptance: Arc<RwLock<OriginAcceptance>>,
+    pub(crate) acceptance_lock: Arc<Mutex<()>>,
 }
 
 impl OriginForwarder {
@@ -36,6 +60,8 @@ impl OriginForwarder {
             url: Arc::new(url.to_string()),
             block_number,
             starknet_client: JsonRpcClient::new(HttpTransport::new(url)),
+            acceptance: Default::default(),
+            acceptance_lock: Default::default(),
         }
     }
 
@@ -45,9 +71,15 @@ impl OriginForwarder {
 
     /// In case block tag "pre_confirmed" or "latest" is a part of the request, it is replaced with
     /// the numeric block id of the forked block. Both JSON-RPC 1 and 2 semantics is covered
-    fn clone_call_with_origin_block_id(&self, rpc_call: &RpcMethodCall) -> RpcMethodCall {
+    fn clone_call_with_origin_block_id(
+        &self,
+        rpc_call: &RpcMethodCall,
+        accepted_on_l1_through: Option<u64>,
+    ) -> RpcMethodCall {
         let mut new_rpc_call = rpc_call.clone();
         let origin_block_id = json!({ "block_number": self.block_number });
+        let l1_accepted_block_id =
+            json!({ "block_number": accepted_on_l1_through.unwrap_or(self.block_number) });
 
         match new_rpc_call.params {
             crate::rpc_core::request::RequestParams::None => (),
@@ -59,8 +91,10 @@ impl OriginForwarder {
                             break;
                         }
                         Some("l1_accepted") => {
-                            tracing::warn!("Assuming fork block is ACCEPTED_ON_L1");
-                            *param = origin_block_id;
+                            if accepted_on_l1_through.is_none() {
+                                tracing::warn!("Assuming fork block is ACCEPTED_ON_L1");
+                            }
+                            *param = l1_accepted_block_id;
                             break;
                         }
                         _ => (),
@@ -74,8 +108,10 @@ impl OriginForwarder {
                             *block_id = origin_block_id;
                         }
                         Some("l1_accepted") => {
-                            tracing::warn!("Assuming fork block is ACCEPTED_ON_L1");
-                            *block_id = origin_block_id;
+                            if accepted_on_l1_through.is_none() {
+                                tracing::warn!("Assuming fork block is ACCEPTED_ON_L1");
+                            }
+                            *block_id = l1_accepted_block_id;
                         }
                         _ => (),
                     }
@@ -85,29 +121,40 @@ impl OriginForwarder {
         new_rpc_call
     }
 
-    async fn call_with_error_handling(
-        &self,
-        rpc_call: &RpcMethodCall,
-    ) -> Result<ResponseResult, anyhow::Error> {
-        let rpc_call = self.clone_call_with_origin_block_id(rpc_call);
+    pub async fn call(&self, rpc_call: &RpcMethodCall) -> ResponseResult {
+        match self.try_call(rpc_call).await {
+            Ok(result) => result,
+            Err(e) => ResponseResult::Error(RpcError::internal_error_with::<String>(format!(
+                "Error in interacting with origin: {e}"
+            ))),
+        }
+    }
+
+    async fn try_call(&self, rpc_call: &RpcMethodCall) -> Result<ResponseResult, anyhow::Error> {
+        let accepted_on_l1_through = self.acceptance.read().await.accepted_on_l1_through;
+        let interception =
+            AcceptanceResponseKind::from_method(&rpc_call.method).zip(accepted_on_l1_through);
+        let forwarded_call =
+            self.clone_call_with_origin_block_id(rpc_call, interception.map(|(_, number)| number));
         let origin_rpc_resp: RpcResponse = self
             .reqwest_client
             .post(self.url.to_string())
-            .json(&rpc_call)
+            .json(&forwarded_call)
             .send()
             .await?
             .json()
             .await?;
 
-        Ok(origin_rpc_resp.result)
-    }
-
-    pub async fn call(&self, rpc_call: &RpcMethodCall) -> ResponseResult {
-        match self.call_with_error_handling(rpc_call).await {
-            Ok(result) => result,
-            Err(e) => ResponseResult::Error(RpcError::internal_error_with::<String>(format!(
-                "Error in interacting with origin: {e}"
-            ))),
+        match interception {
+            Some((response_kind, accepted_on_l1_through)) => Ok(self
+                .intercept_response(
+                    rpc_call,
+                    origin_rpc_resp.result,
+                    response_kind,
+                    accepted_on_l1_through,
+                )
+                .await),
+            None => Ok(origin_rpc_resp.result),
         }
     }
 
@@ -123,6 +170,194 @@ impl OriginForwarder {
                 },
             )),
         }
+    }
+
+    async fn get_origin_block(
+        &self,
+        block_id: ImportedBlockId,
+    ) -> Result<BlockWithTxHashes, ApiError> {
+        match self.starknet_client.get_block_with_tx_hashes(block_id).await {
+            Ok(MaybePreConfirmedBlockWithTxHashes::Block(block)) => Ok(block),
+            Ok(MaybePreConfirmedBlockWithTxHashes::PreConfirmedBlock(_)) => {
+                Err(ApiError::StarknetDevnetError(starknet_core::error::Error::UnsupportedAction {
+                    msg: "Pre-confirmed block cannot be accepted on L1".into(),
+                }))
+            }
+            Err(starknet_rs_providers::ProviderError::StarknetError(
+                starknet_rs_core::types::StarknetError::BlockNotFound,
+            )) => Err(ApiError::StarknetDevnetError(starknet_core::error::Error::NoBlock)),
+            Err(error) => Err(ApiError::StarknetDevnetError(
+                starknet_core::error::Error::UnexpectedInternalError {
+                    msg: format!("Error in retrieving a block from forking origin: {error}"),
+                },
+            )),
+        }
+    }
+
+    pub(crate) async fn resolve_origin_block_number(
+        &self,
+        block_id: BlockId,
+    ) -> Result<u64, ApiError> {
+        let starting_block_id = match block_id {
+            BlockId::Tag(BlockTag::Latest | BlockTag::PreConfirmed) => {
+                ImportedBlockId::Number(self.block_number)
+            }
+            other => ImportedBlockId::from(other),
+        };
+        let block = self.get_origin_block(starting_block_id).await?;
+
+        if block.block_number > self.block_number {
+            return Err(ApiError::StarknetDevnetError(starknet_core::error::Error::NoBlock));
+        }
+
+        let previously_accepted_through = self.acceptance.read().await.accepted_on_l1_through;
+        if previously_accepted_through.is_some_and(|number| block.block_number <= number) {
+            return Err(ApiError::StarknetDevnetError(
+                starknet_core::error::Error::UnsupportedAction {
+                    msg: "Block already accepted on L1".into(),
+                },
+            ));
+        }
+
+        match block.status {
+            ImportedBlockStatus::AcceptedOnL2 => Ok(block.block_number),
+            ImportedBlockStatus::AcceptedOnL1 => {
+                Err(ApiError::StarknetDevnetError(starknet_core::error::Error::UnsupportedAction {
+                    msg: "Block already accepted on L1".into(),
+                }))
+            }
+            _ => {
+                Err(ApiError::StarknetDevnetError(starknet_core::error::Error::UnsupportedAction {
+                    msg: "Only blocks accepted on L2 can be accepted on L1".into(),
+                }))
+            }
+        }
+    }
+
+    pub(crate) async fn set_accepted_on_l1_through(&self, block_number: u64) {
+        let mut acceptance = self.acceptance.write().await;
+        acceptance.accepted_on_l1_through = Some(
+            acceptance
+                .accepted_on_l1_through
+                .map_or(block_number, |current| current.max(block_number)),
+        );
+    }
+
+    pub(crate) async fn reset_acceptance(&self) {
+        *self.acceptance.write().await = OriginAcceptance::default();
+    }
+
+    async fn intercept_response(
+        &self,
+        rpc_call: &RpcMethodCall,
+        mut response: ResponseResult,
+        response_kind: AcceptanceResponseKind,
+        accepted_on_l1_through: u64,
+    ) -> ResponseResult {
+        let ResponseResult::Success(value) = &mut response else {
+            return response;
+        };
+
+        if response_kind == AcceptanceResponseKind::MessagesStatus {
+            self.intercept_messages_status(value, accepted_on_l1_through).await;
+            return response;
+        }
+
+        let block_number = if let Some(block_number) = block_number_from_response(value) {
+            Some(block_number)
+        } else if response_kind == AcceptanceResponseKind::TransactionStatus {
+            match transaction_hash_from_call(rpc_call) {
+                Some(transaction_hash) => self.transaction_block_number(transaction_hash).await,
+                None => None,
+            }
+        } else {
+            None
+        };
+
+        if block_number.is_none_or(|number| number > accepted_on_l1_through) {
+            return response;
+        }
+
+        match response_kind {
+            AcceptanceResponseKind::Block => promote_status(value, "status"),
+            AcceptanceResponseKind::BlockWithReceipts => {
+                promote_status(value, "status");
+                if let Some(transactions) =
+                    value.get_mut("transactions").and_then(serde_json::Value::as_array_mut)
+                {
+                    for transaction in transactions {
+                        if let Some(receipt) = transaction.get_mut("receipt") {
+                            promote_status(receipt, "finality_status");
+                        }
+                    }
+                }
+            }
+            AcceptanceResponseKind::TransactionReceipt
+            | AcceptanceResponseKind::TransactionStatus => {
+                promote_status(value, "finality_status");
+            }
+            AcceptanceResponseKind::MessagesStatus => {}
+        }
+
+        response
+    }
+
+    async fn intercept_messages_status(
+        &self,
+        value: &mut serde_json::Value,
+        accepted_on_l1_through: u64,
+    ) {
+        let transaction_hashes = value
+            .as_array()
+            .map(|statuses| {
+                statuses
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(index, status)| {
+                        status
+                            .get("transaction_hash")
+                            .cloned()
+                            .and_then(|hash| serde_json::from_value(hash).ok())
+                            .map(|hash| (index, hash))
+                    })
+                    .collect::<Vec<(usize, Felt)>>()
+            })
+            .unwrap_or_default();
+
+        for (index, transaction_hash) in transaction_hashes {
+            if self
+                .transaction_block_number(transaction_hash)
+                .await
+                .is_some_and(|number| number <= accepted_on_l1_through)
+                && let Some(status) = value.get_mut(index)
+            {
+                promote_status(status, "finality_status");
+            }
+        }
+    }
+
+    async fn transaction_block_number(&self, transaction_hash: Felt) -> Option<u64> {
+        let cached_block_number =
+            self.acceptance.write().await.transaction_block_numbers.get(&transaction_hash).copied();
+        if let Some(block_number) = cached_block_number {
+            return Some(block_number);
+        }
+
+        let receipt = match self.starknet_client.get_transaction_receipt(transaction_hash).await {
+            Ok(receipt) => receipt,
+            Err(error) => {
+                tracing::warn!(
+                    %transaction_hash,
+                    %error,
+                    "Could not resolve origin transaction block number for L1 acceptance"
+                );
+                return None;
+            }
+        };
+        let block_number = receipt.block.block_number();
+        self.acceptance.write().await.transaction_block_numbers.put(transaction_hash, block_number);
+
+        Some(block_number)
     }
 
     /// Only use with confirmed block ID
@@ -153,12 +388,56 @@ impl OriginForwarder {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AcceptanceResponseKind {
+    Block,
+    BlockWithReceipts,
+    TransactionReceipt,
+    TransactionStatus,
+    MessagesStatus,
+}
+
+impl AcceptanceResponseKind {
+    fn from_method(method: &str) -> Option<Self> {
+        match method {
+            "starknet_getBlockWithTxHashes" | "starknet_getBlockWithTxs" => Some(Self::Block),
+            "starknet_getBlockWithReceipts" => Some(Self::BlockWithReceipts),
+            "starknet_getTransactionReceipt" => Some(Self::TransactionReceipt),
+            "starknet_getTransactionStatus" => Some(Self::TransactionStatus),
+            "starknet_getMessagesStatus" => Some(Self::MessagesStatus),
+            _ => None,
+        }
+    }
+}
+
+fn block_number_from_response(value: &serde_json::Value) -> Option<u64> {
+    value.get("block_number").and_then(serde_json::Value::as_u64)
+}
+
+fn promote_status(value: &mut serde_json::Value, field: &str) {
+    if value.get(field).and_then(serde_json::Value::as_str) == Some("ACCEPTED_ON_L2") {
+        value[field] = serde_json::Value::String("ACCEPTED_ON_L1".into());
+    }
+}
+
+fn transaction_hash_from_call(rpc_call: &RpcMethodCall) -> Option<Felt> {
+    let value = match &rpc_call.params {
+        RequestParams::Array(params) => params.first(),
+        RequestParams::Object(params) => params.get("transaction_hash"),
+        RequestParams::None => None,
+    }?;
+
+    serde_json::from_value(value.clone()).ok()
+}
+
 #[cfg(test)]
 mod tests {
     use serde_json::json;
+    use starknet_rs_core::types::Felt;
 
-    use super::OriginForwarder;
+    use super::{AcceptanceResponseKind, OriginForwarder, TRANSACTION_BLOCK_NUMBER_CACHE_CAPACITY};
     use crate::rpc_core::request::RpcMethodCall;
+    use crate::rpc_core::response::ResponseResult;
 
     #[test]
     fn test_replacing_block_id() {
@@ -194,7 +473,7 @@ mod tests {
             orig_body["params"] = orig_params;
 
             let request: RpcMethodCall = serde_json::from_value(orig_body).unwrap();
-            let replaced_request = forwarder.clone_call_with_origin_block_id(&request);
+            let replaced_request = forwarder.clone_call_with_origin_block_id(&request, None);
             let replaced_request_json = serde_json::to_value(replaced_request).unwrap();
 
             let mut expected_body = common_body.clone();
@@ -203,5 +482,242 @@ mod tests {
 
             assert_eq!(replaced_request_json, expected_body);
         }
+    }
+
+    #[test]
+    fn l1_accepted_tag_uses_simulated_boundary_when_present() {
+        let forwarder = OriginForwarder::new(url::Url::parse("http://dummy.com").unwrap(), 10);
+        let request: RpcMethodCall = serde_json::from_value(json!({
+            "jsonrpc": "2.0",
+            "method": "starknet_getBlockWithTxHashes",
+            "params": { "block_id": "l1_accepted" },
+            "id": 1,
+        }))
+        .unwrap();
+
+        let unchanged = forwarder.clone_call_with_origin_block_id(&request, None);
+        let simulated = forwarder.clone_call_with_origin_block_id(&request, Some(7));
+
+        assert_eq!(
+            serde_json::to_value(unchanged).unwrap()["params"]["block_id"],
+            json!({ "block_number": 10 })
+        );
+        assert_eq!(
+            serde_json::to_value(simulated).unwrap()["params"]["block_id"],
+            json!({ "block_number": 7 })
+        );
+    }
+
+    #[test]
+    fn acceptance_response_subset_is_explicit() {
+        for method in [
+            "starknet_getBlockWithTxHashes",
+            "starknet_getBlockWithTxs",
+            "starknet_getBlockWithReceipts",
+            "starknet_getTransactionReceipt",
+            "starknet_getTransactionStatus",
+            "starknet_getMessagesStatus",
+        ] {
+            assert!(AcceptanceResponseKind::from_method(method).is_some());
+        }
+        assert!(AcceptanceResponseKind::from_method("starknet_getTransactionByHash").is_none());
+    }
+
+    #[tokio::test]
+    async fn interception_is_dormant_until_acceptance_boundary_is_set() {
+        let forwarder = OriginForwarder::new(url::Url::parse("http://dummy.com").unwrap(), 10);
+        let request: RpcMethodCall = serde_json::from_value(json!({
+            "jsonrpc": "2.0",
+            "method": "starknet_getBlockWithTxHashes",
+            "params": { "block_id": { "block_number": 5 } },
+            "id": 1,
+        }))
+        .unwrap();
+        let response = ResponseResult::Success(json!({
+            "block_number": 5,
+            "status": "ACCEPTED_ON_L2",
+        }));
+
+        assert!(forwarder.acceptance.read().await.accepted_on_l1_through.is_none());
+
+        forwarder.set_accepted_on_l1_through(5).await;
+
+        assert_eq!(forwarder.acceptance.read().await.accepted_on_l1_through, Some(5));
+        assert!(forwarder.acceptance.read().await.transaction_block_numbers.is_empty());
+        assert_eq!(
+            forwarder
+                .intercept_response(&request, response, AcceptanceResponseKind::Block, 5,)
+                .await,
+            ResponseResult::Success(json!({
+                "block_number": 5,
+                "status": "ACCEPTED_ON_L1",
+            }))
+        );
+    }
+
+    #[tokio::test]
+    async fn interception_promotes_origin_transaction_receipts_and_statuses() {
+        let forwarder = OriginForwarder::new(url::Url::parse("http://dummy.com").unwrap(), 10);
+        let transaction_hash = Felt::from(123_u64);
+        forwarder.set_accepted_on_l1_through(5).await;
+
+        let receipt_request: RpcMethodCall = serde_json::from_value(json!({
+            "jsonrpc": "2.0",
+            "method": "starknet_getTransactionReceipt",
+            "params": { "transaction_hash": transaction_hash },
+            "id": 1,
+        }))
+        .unwrap();
+        let receipt = ResponseResult::Success(json!({
+            "block_number": 5,
+            "finality_status": "ACCEPTED_ON_L2",
+        }));
+        assert_eq!(
+            forwarder
+                .intercept_response(
+                    &receipt_request,
+                    receipt,
+                    AcceptanceResponseKind::TransactionReceipt,
+                    5,
+                )
+                .await,
+            ResponseResult::Success(json!({
+                "block_number": 5,
+                "finality_status": "ACCEPTED_ON_L1",
+            }))
+        );
+
+        forwarder.acceptance.write().await.transaction_block_numbers.put(transaction_hash, 5);
+        let status_request: RpcMethodCall = serde_json::from_value(json!({
+            "jsonrpc": "2.0",
+            "method": "starknet_getTransactionStatus",
+            "params": { "transaction_hash": transaction_hash },
+            "id": 1,
+        }))
+        .unwrap();
+        let status = ResponseResult::Success(json!({
+            "finality_status": "ACCEPTED_ON_L2",
+            "execution_status": "SUCCEEDED",
+        }));
+        assert_eq!(
+            forwarder
+                .intercept_response(
+                    &status_request,
+                    status,
+                    AcceptanceResponseKind::TransactionStatus,
+                    5,
+                )
+                .await,
+            ResponseResult::Success(json!({
+                "finality_status": "ACCEPTED_ON_L1",
+                "execution_status": "SUCCEEDED",
+            }))
+        );
+    }
+
+    #[tokio::test]
+    async fn interception_promotes_receipts_nested_in_accepted_origin_block() {
+        let forwarder = OriginForwarder::new(url::Url::parse("http://dummy.com").unwrap(), 10);
+        forwarder.set_accepted_on_l1_through(5).await;
+        let request: RpcMethodCall = serde_json::from_value(json!({
+            "jsonrpc": "2.0",
+            "method": "starknet_getBlockWithReceipts",
+            "params": { "block_id": { "block_number": 5 } },
+            "id": 1,
+        }))
+        .unwrap();
+        let response = ResponseResult::Success(json!({
+            "block_number": 5,
+            "status": "ACCEPTED_ON_L2",
+            "transactions": [{
+                "transaction": {},
+                "receipt": { "finality_status": "ACCEPTED_ON_L2" },
+            }],
+        }));
+
+        assert_eq!(
+            forwarder
+                .intercept_response(
+                    &request,
+                    response,
+                    AcceptanceResponseKind::BlockWithReceipts,
+                    5,
+                )
+                .await,
+            ResponseResult::Success(json!({
+                "block_number": 5,
+                "status": "ACCEPTED_ON_L1",
+                "transactions": [{
+                    "transaction": {},
+                    "receipt": { "finality_status": "ACCEPTED_ON_L1" },
+                }],
+            }))
+        );
+    }
+
+    #[tokio::test]
+    async fn interception_promotes_only_covered_message_statuses() {
+        let forwarder = OriginForwarder::new(url::Url::parse("http://dummy.com").unwrap(), 10);
+        let covered_transaction_hash = Felt::from(123_u64);
+        let uncovered_transaction_hash = Felt::from(456_u64);
+        {
+            let mut acceptance = forwarder.acceptance.write().await;
+            acceptance.transaction_block_numbers.put(covered_transaction_hash, 5);
+            acceptance.transaction_block_numbers.put(uncovered_transaction_hash, 6);
+        }
+        let request: RpcMethodCall = serde_json::from_value(json!({
+            "jsonrpc": "2.0",
+            "method": "starknet_getMessagesStatus",
+            "params": { "transaction_hash": Felt::ONE },
+            "id": 1,
+        }))
+        .unwrap();
+        let response = ResponseResult::Success(json!([
+            {
+                "transaction_hash": covered_transaction_hash,
+                "finality_status": "ACCEPTED_ON_L2",
+            },
+            {
+                "transaction_hash": uncovered_transaction_hash,
+                "finality_status": "ACCEPTED_ON_L2",
+            },
+        ]));
+
+        assert_eq!(
+            forwarder
+                .intercept_response(&request, response, AcceptanceResponseKind::MessagesStatus, 5,)
+                .await,
+            ResponseResult::Success(json!([
+                {
+                    "transaction_hash": covered_transaction_hash,
+                    "finality_status": "ACCEPTED_ON_L1",
+                },
+                {
+                    "transaction_hash": uncovered_transaction_hash,
+                    "finality_status": "ACCEPTED_ON_L2",
+                },
+            ]))
+        );
+    }
+
+    #[tokio::test]
+    async fn transaction_block_number_cache_is_bounded() {
+        let forwarder = OriginForwarder::new(url::Url::parse("http://dummy.com").unwrap(), 10);
+        let mut acceptance = forwarder.acceptance.write().await;
+
+        for number in 0..=TRANSACTION_BLOCK_NUMBER_CACHE_CAPACITY as u64 {
+            acceptance.transaction_block_numbers.put(Felt::from(number), number);
+        }
+
+        assert_eq!(
+            acceptance.transaction_block_numbers.len(),
+            TRANSACTION_BLOCK_NUMBER_CACHE_CAPACITY
+        );
+        assert!(!acceptance.transaction_block_numbers.contains(&Felt::ZERO));
+        assert!(
+            acceptance
+                .transaction_block_numbers
+                .contains(&Felt::from(TRANSACTION_BLOCK_NUMBER_CACHE_CAPACITY as u64))
+        );
     }
 }

--- a/crates/starknet-devnet-server/src/api/origin_forwarder.rs
+++ b/crates/starknet-devnet-server/src/api/origin_forwarder.rs
@@ -134,8 +134,7 @@ impl OriginForwarder {
         let accepted_on_l1_through = self.acceptance.read().await.accepted_on_l1_through;
         let interception =
             AcceptanceResponseKind::from_method(&rpc_call.method).zip(accepted_on_l1_through);
-        let forwarded_call =
-            self.clone_call_with_origin_block_id(rpc_call, interception.map(|(_, number)| number));
+        let forwarded_call = self.clone_call_with_origin_block_id(rpc_call, accepted_on_l1_through);
         let origin_rpc_resp: RpcResponse = self
             .reqwest_client
             .post(self.url.to_string())
@@ -366,6 +365,10 @@ impl OriginForwarder {
         block_id: BlockId,
     ) -> Result<u64, ApiError> {
         if block_id == BlockId::Tag(BlockTag::L1Accepted) {
+            if let Some(block_number) = self.acceptance.read().await.accepted_on_l1_through {
+                return Ok(block_number);
+            }
+
             let l1_accepted_block = self.get_l1_accepted_block().await?;
             return Ok(std::cmp::min(l1_accepted_block.block_number, self.fork_block_number()));
         }

--- a/crates/starknet-devnet-server/src/api/write_endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/write_endpoints.rs
@@ -251,7 +251,28 @@ impl JsonRpcHandler {
 
     /// devnet_acceptOnL1
     pub async fn accept_on_l1(&self, data: AcceptOnL1Request) -> StrictRpcResult {
-        let accepted = self.api.starknet.lock().await.accept_on_l1(data.starting_block_id)?;
+        let Some(origin_caller) = &self.origin_caller else {
+            let accepted = self.api.starknet.lock().await.accept_on_l1(data.starting_block_id)?;
+            return Ok(DevnetResponse::AcceptedOnL1Blocks(AcceptedOnL1Blocks { accepted }).into());
+        };
+
+        let _acceptance_guard = origin_caller.acceptance_lock.lock().await;
+        let local_acceptance = self.api.starknet.lock().await.accept_on_l1(data.starting_block_id);
+
+        let accepted = match local_acceptance {
+            Ok(accepted) => {
+                origin_caller.set_accepted_on_l1_through(origin_caller.fork_block_number()).await;
+                accepted
+            }
+            Err(starknet_core::error::Error::NoBlock) => {
+                let origin_block_number =
+                    origin_caller.resolve_origin_block_number(data.starting_block_id).await?;
+                origin_caller.set_accepted_on_l1_through(origin_block_number).await;
+                Vec::new()
+            }
+            Err(error) => return Err(ApiError::StarknetDevnetError(error)),
+        };
+
         Ok(DevnetResponse::AcceptedOnL1Blocks(AcceptedOnL1Blocks { accepted }).into())
     }
 
@@ -267,8 +288,16 @@ impl JsonRpcHandler {
     pub async fn restart(&self, data: Option<RestartParameters>) -> StrictRpcResult {
         self.api.dumpable_events.lock().await.clear();
 
+        let _acceptance_guard = if let Some(origin_caller) = &self.origin_caller {
+            Some(origin_caller.acceptance_lock.lock().await)
+        } else {
+            None
+        };
         let restart_params = data.unwrap_or_default();
         self.api.starknet.lock().await.restart(restart_params.restart_l1_to_l2_messaging)?;
+        if let Some(origin_caller) = &self.origin_caller {
+            origin_caller.reset_acceptance().await;
+        }
 
         self.api.sockets.lock().await.clear();
 

--- a/tests/integration/accepting_blocks_on_l1.rs
+++ b/tests/integration/accepting_blocks_on_l1.rs
@@ -1,12 +1,14 @@
+use serde_json::json;
 use starknet_rs_core::types::{
     BlockId, BlockStatus, BlockTag, Felt, MaybePreConfirmedBlockWithTxHashes,
-    SequencerTransactionStatus, StarknetError,
+    SequencerTransactionStatus, StarknetError, TransactionFinalityStatus,
 };
 use starknet_rs_providers::{Provider, ProviderError};
 
 use crate::assert_eq_prop;
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::errors::RpcError;
+use crate::common::utils::{UniqueAutoDeletableFile, send_ctrl_c_signal_and_wait};
 
 /// Returns the hash of the dummy tx
 async fn send_dummy_tx(devnet: &BackgroundDevnet) -> Felt {
@@ -47,6 +49,14 @@ async fn assert_latest_accepted_on_l2(devnet: &BackgroundDevnet) -> Result<(), a
     }
 
     Ok(())
+}
+
+async fn assert_block_status(devnet: &BackgroundDevnet, block_hash: Felt, expected: BlockStatus) {
+    match devnet.json_rpc_client.get_block_with_tx_hashes(BlockId::Hash(block_hash)).await.unwrap()
+    {
+        MaybePreConfirmedBlockWithTxHashes::Block(block) => assert_eq!(block.status, expected),
+        other => panic!("Unexpected block response: {other:?}"),
+    }
 }
 
 #[tokio::test]
@@ -172,6 +182,157 @@ async fn origin_block_should_be_acceptable_on_l1() {
 
     origin_block.status = BlockStatus::AcceptedOnL1;
     assert_eq!(origin_block, l1_accepted_block);
+}
+
+#[tokio::test]
+async fn should_accept_local_and_origin_blocks_on_l1_in_forking_mode() {
+    let origin_devnet = BackgroundDevnet::spawn_forkable_devnet().await.unwrap();
+    let origin_genesis = origin_devnet.get_latest_block_with_tx_hashes().await.unwrap();
+
+    let first_origin_tx = send_dummy_tx(&origin_devnet).await;
+    let first_origin_block = origin_devnet.get_latest_block_with_tx_hashes().await.unwrap();
+    let second_origin_tx = send_dummy_tx(&origin_devnet).await;
+    let second_origin_block = origin_devnet.get_latest_block_with_tx_hashes().await.unwrap();
+
+    let fork_devnet = origin_devnet.fork().await.unwrap();
+    let local_block = fork_devnet.get_latest_block_with_tx_hashes().await.unwrap();
+
+    // Forwarding is unchanged before devnet_acceptOnL1 activates the overlay.
+    assert_block_status(&fork_devnet, second_origin_block.block_hash, BlockStatus::AcceptedOnL2)
+        .await;
+
+    let accepted = fork_devnet.accept_on_l1(&BlockId::Tag(BlockTag::Latest)).await.unwrap();
+    assert_eq!(accepted, vec![local_block.block_hash]);
+
+    for block_hash in [
+        local_block.block_hash,
+        second_origin_block.block_hash,
+        first_origin_block.block_hash,
+        origin_genesis.block_hash,
+    ] {
+        assert_block_status(&fork_devnet, block_hash, BlockStatus::AcceptedOnL1).await;
+    }
+
+    assert_accepted_on_l1(
+        &fork_devnet,
+        &[second_origin_block.block_hash, first_origin_block.block_hash],
+        &[first_origin_tx, second_origin_tx],
+    )
+    .await
+    .unwrap();
+
+    let receipt =
+        fork_devnet.json_rpc_client.get_transaction_receipt(first_origin_tx).await.unwrap().receipt;
+    assert_eq!(receipt.finality_status(), &TransactionFinalityStatus::AcceptedOnL1);
+
+    // The overlay must not mutate the origin itself.
+    assert_block_status(&origin_devnet, second_origin_block.block_hash, BlockStatus::AcceptedOnL2)
+        .await;
+    let origin_tx_status =
+        origin_devnet.json_rpc_client.get_transaction_status(first_origin_tx).await.unwrap();
+    assert_eq!(origin_tx_status.finality_status(), SequencerTransactionStatus::AcceptedOnL2);
+}
+
+#[tokio::test]
+async fn should_move_origin_l1_boundary_without_accepting_newer_blocks() {
+    let origin_devnet = BackgroundDevnet::spawn_forkable_devnet().await.unwrap();
+    let origin_genesis = origin_devnet.get_latest_block_with_tx_hashes().await.unwrap();
+
+    let first_origin_tx = send_dummy_tx(&origin_devnet).await;
+    let first_origin_block = origin_devnet.get_latest_block_with_tx_hashes().await.unwrap();
+    let second_origin_tx = send_dummy_tx(&origin_devnet).await;
+    let second_origin_block = origin_devnet.get_latest_block_with_tx_hashes().await.unwrap();
+
+    let fork_devnet = origin_devnet.fork().await.unwrap();
+    let local_block = fork_devnet.get_latest_block_with_tx_hashes().await.unwrap();
+
+    let accepted = fork_devnet.accept_on_l1(&BlockId::Number(1)).await.unwrap();
+    assert!(accepted.is_empty());
+
+    assert_block_status(&fork_devnet, origin_genesis.block_hash, BlockStatus::AcceptedOnL1).await;
+    assert_block_status(&fork_devnet, first_origin_block.block_hash, BlockStatus::AcceptedOnL1)
+        .await;
+    assert_block_status(&fork_devnet, second_origin_block.block_hash, BlockStatus::AcceptedOnL2)
+        .await;
+    assert_block_status(&fork_devnet, local_block.block_hash, BlockStatus::AcceptedOnL2).await;
+
+    let first_status =
+        fork_devnet.json_rpc_client.get_transaction_status(first_origin_tx).await.unwrap();
+    let second_status =
+        fork_devnet.json_rpc_client.get_transaction_status(second_origin_tx).await.unwrap();
+    assert_eq!(first_status.finality_status(), SequencerTransactionStatus::AcceptedOnL1);
+    assert_eq!(second_status.finality_status(), SequencerTransactionStatus::AcceptedOnL2);
+
+    let l1_accepted = fork_devnet.get_l1_accepted_block_with_tx_hashes().await.unwrap();
+    assert_eq!(l1_accepted.block_hash, first_origin_block.block_hash);
+
+    let accepted =
+        fork_devnet.accept_on_l1(&BlockId::Hash(second_origin_block.block_hash)).await.unwrap();
+    assert!(accepted.is_empty());
+    assert_block_status(&fork_devnet, second_origin_block.block_hash, BlockStatus::AcceptedOnL1)
+        .await;
+    assert_block_status(&fork_devnet, local_block.block_hash, BlockStatus::AcceptedOnL2).await;
+
+    let err =
+        fork_devnet.accept_on_l1(&BlockId::Hash(second_origin_block.block_hash)).await.unwrap_err();
+    assert_eq!(
+        err,
+        RpcError { code: -1, message: "Block already accepted on L1".into(), data: None }
+    );
+}
+
+#[tokio::test]
+async fn restart_should_clear_origin_acceptance_overlay() {
+    let origin_devnet = BackgroundDevnet::spawn_forkable_devnet().await.unwrap();
+    send_dummy_tx(&origin_devnet).await;
+    let origin_block = origin_devnet.get_latest_block_with_tx_hashes().await.unwrap();
+    let fork_devnet = origin_devnet.fork().await.unwrap();
+
+    fork_devnet.accept_on_l1(&BlockId::Number(origin_block.block_number)).await.unwrap();
+    assert_block_status(&fork_devnet, origin_block.block_hash, BlockStatus::AcceptedOnL1).await;
+
+    fork_devnet.restart().await;
+    assert_block_status(&fork_devnet, origin_block.block_hash, BlockStatus::AcceptedOnL2).await;
+}
+
+#[tokio::test]
+async fn dump_and_load_should_reconstruct_origin_acceptance_overlay() {
+    let origin_devnet = BackgroundDevnet::spawn_forkable_devnet().await.unwrap();
+    let origin_tx = send_dummy_tx(&origin_devnet).await;
+    let origin_block = origin_devnet.get_latest_block_with_tx_hashes().await.unwrap();
+    let fork_devnet = BackgroundDevnet::spawn_with_additional_args(&[
+        "--fork-network",
+        &origin_devnet.url,
+        "--dump-on",
+        "request",
+    ])
+    .await
+    .unwrap();
+    let dump_file = UniqueAutoDeletableFile::new("fork_origin_acceptance");
+
+    fork_devnet.accept_on_l1(&BlockId::Number(origin_block.block_number)).await.unwrap();
+    fork_devnet.send_custom_rpc("devnet_dump", json!({ "path": dump_file.path })).await.unwrap();
+
+    fork_devnet.restart().await;
+    assert_block_status(&fork_devnet, origin_block.block_hash, BlockStatus::AcceptedOnL2).await;
+
+    fork_devnet.send_custom_rpc("devnet_load", json!({ "path": dump_file.path })).await.unwrap();
+    assert_block_status(&fork_devnet, origin_block.block_hash, BlockStatus::AcceptedOnL1).await;
+    let tx_status = fork_devnet.json_rpc_client.get_transaction_status(origin_tx).await.unwrap();
+    assert_eq!(tx_status.finality_status(), SequencerTransactionStatus::AcceptedOnL1);
+}
+
+#[tokio::test]
+async fn local_acceptance_should_not_require_origin() {
+    let origin_devnet = BackgroundDevnet::spawn_forkable_devnet().await.unwrap();
+    send_dummy_tx(&origin_devnet).await;
+    let fork_devnet = origin_devnet.fork().await.unwrap();
+    let local_block = fork_devnet.get_latest_block_with_tx_hashes().await.unwrap();
+    send_ctrl_c_signal_and_wait(&origin_devnet.process).await;
+
+    let accepted = fork_devnet.accept_on_l1(&BlockId::Tag(BlockTag::Latest)).await.unwrap();
+    assert_eq!(accepted, vec![local_block.block_hash]);
+    assert_block_status(&fork_devnet, local_block.block_hash, BlockStatus::AcceptedOnL1).await;
 }
 
 #[tokio::test]

--- a/tests/integration/accepting_blocks_on_l1.rs
+++ b/tests/integration/accepting_blocks_on_l1.rs
@@ -1,6 +1,6 @@
 use serde_json::json;
 use starknet_rs_core::types::{
-    BlockId, BlockStatus, BlockTag, Felt, MaybePreConfirmedBlockWithTxHashes,
+    BlockId, BlockStatus, BlockTag, EventFilter, Felt, MaybePreConfirmedBlockWithTxHashes,
     SequencerTransactionStatus, StarknetError, TransactionFinalityStatus,
 };
 use starknet_rs_providers::{Provider, ProviderError};
@@ -279,6 +279,66 @@ async fn should_move_origin_l1_boundary_without_accepting_newer_blocks() {
         err,
         RpcError { code: -1, message: "Block already accepted on L1".into(), data: None }
     );
+}
+
+#[tokio::test]
+async fn l1_accepted_should_use_overlay_for_non_status_requests() {
+    let origin_devnet = BackgroundDevnet::spawn_forkable_devnet().await.unwrap();
+    let origin_genesis = origin_devnet.get_latest_block_with_tx_hashes().await.unwrap();
+    send_dummy_tx(&origin_devnet).await;
+    let fork_devnet = origin_devnet.fork().await.unwrap();
+
+    fork_devnet.accept_on_l1(&BlockId::Number(origin_genesis.block_number)).await.unwrap();
+
+    let expected_count = origin_devnet
+        .json_rpc_client
+        .get_block_transaction_count(BlockId::Number(origin_genesis.block_number))
+        .await
+        .unwrap();
+    let fork_block_count = origin_devnet
+        .json_rpc_client
+        .get_block_transaction_count(BlockId::Tag(BlockTag::Latest))
+        .await
+        .unwrap();
+    assert_ne!(expected_count, fork_block_count);
+
+    let actual_count = fork_devnet
+        .json_rpc_client
+        .get_block_transaction_count(BlockId::Tag(BlockTag::L1Accepted))
+        .await
+        .unwrap();
+
+    assert_eq!(actual_count, expected_count);
+}
+
+#[tokio::test]
+async fn l1_accepted_should_use_overlay_for_event_ranges() {
+    let origin_devnet = BackgroundDevnet::spawn_forkable_devnet().await.unwrap();
+    let origin_genesis = origin_devnet.get_latest_block_with_tx_hashes().await.unwrap();
+    send_dummy_tx(&origin_devnet).await;
+    let fork_devnet = origin_devnet.fork().await.unwrap();
+
+    fork_devnet.accept_on_l1(&BlockId::Number(origin_genesis.block_number)).await.unwrap();
+
+    let events = fork_devnet
+        .json_rpc_client
+        .get_events(
+            EventFilter {
+                from_block: Some(BlockId::Tag(BlockTag::L1Accepted)),
+                to_block: Some(BlockId::Tag(BlockTag::L1Accepted)),
+                address: None,
+                keys: None,
+            },
+            None,
+            100,
+        )
+        .await
+        .unwrap();
+
+    assert!(events.events.iter().all(|event| {
+        event.block_number == Some(origin_genesis.block_number)
+            && event.block_hash == Some(origin_genesis.block_hash)
+    }));
 }
 
 #[tokio::test]

--- a/website/docs/blocks.md
+++ b/website/docs/blocks.md
@@ -145,7 +145,10 @@ When aborting the currently `pre_confirmed` block, it is mined and aborted as la
 
 ## Accepting blocks on L1
 
-This functionality allows simulating block acceptance on L1 (Ethereum). It merely marks the requested blocks and their transactions as `ACCEPTED_ON_L1`. It is only supported on blocks that are `ACCEPTED_ON_L2` and fails for all others, including blocks already `ACCEPTED_ON_L1`. In case of [forking](./forking), blocks on forking origin cannot be affected by this feature.
+This functionality allows simulating block acceptance on L1 (Ethereum). It merely marks the requested blocks and their transactions as `ACCEPTED_ON_L1`. It is only supported on blocks that are `ACCEPTED_ON_L2` and fails for all others, including blocks already `ACCEPTED_ON_L1`.
+
+In [forking](./forking) mode, the simulation also applies to blocks and transactions from the forking origin. Their status is overridden only in the forked Devnet; the origin itself is not modified.
+Origin block hashes are not included in the `accepted` response; it lists only locally generated Devnet blocks.
 
 :::note
 

--- a/website/static/devnet_api.json
+++ b/website/static/devnet_api.json
@@ -392,7 +392,7 @@
     },
     {
       "name": "devnet_acceptOnL1",
-      "summary": "Accept on L1 the blocks from starting_block_id to the oldest local block that is accepted on L2",
+      "summary": "Accept on L1 the blocks from starting_block_id to the oldest block that is accepted on L2",
       "params": [
         {
           "name": "starting_block_id",
@@ -406,12 +406,12 @@
       ],
       "result": {
         "name": "result",
-        "description": "Array of block hashes of blocks accepted on L1.",
+        "description": "Array of locally generated Devnet block hashes accepted on L1.",
         "schema": {
           "type": "object",
           "properties": {
             "accepted": {
-              "description": "Accepted blocks hashes",
+              "description": "Accepted local block hashes",
               "type": "array",
               "items": {
                 "$ref": "#/components/schemas/FELT"


### PR DESCRIPTION
## Usage related changes

Calling devnet_acceptOnL1 in fork mode now presents eligible origin blocks, transactions, receipts, and message statuses as ACCEPTED_ON_L1 inside the fork without mutating the upstream node. The response continues to contain only locally generated Devnet block hashes.

The origin overlay remains dormant until the first acceptance call, is monotonic, resets on restart, and is reconstructed by dump/load replay. Lazy transaction block-number lookups use a bounded 1,024-entry LRU cache.

Fixes #945.

## Development related changes

Origin forwarding now intercepts only RPC responses that expose acceptance status. Responses with a block number are handled directly; transaction status and message status responses resolve missing block numbers lazily through receipts.

Coverage includes local acceptance across the fork boundary, origin block numbers and hashes, repeated calls, l1_accepted, restart, dump/load, origin independence, and bounded cache eviction.

## Checklist:

- [x] Checked out the [contribution guidelines](https://github.com/starknet-io/starknet-devnet/blob/main/.github/CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [ ] No unused dependencies - `./scripts/check_unused_deps.sh`
  - The check reports the existing `apollo_compilation_utils` entry in `starknet-devnet-types`; the new `lru` dependency is used.
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    - Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/starknet-io/starknet-devnet/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/starknet-io/starknet-devnet/blob/main/.github/CONTRIBUTING.md#test-execution)