### PR TITLE
fix(build-and-publish): render release body via shell script

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -488,6 +488,19 @@ jobs:
           git config --global user.name "GitHub Actions"
           npm run deploy
 
+      - name: Render release body
+        id: render_release_body
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+          SHA: ${{ needs.prepare.outputs.sha }}
+          IS_RC: ${{ needs.prepare.outputs.is_rc }}
+          DOCKER_REGISTRY: ${{ steps.config.outputs.docker_registry }}
+          DOCKER_NAMESPACE: ${{ steps.config.outputs.docker_namespace }}
+          IMAGE_NAME: ${{ steps.config.outputs.image_name }}
+        run: |
+          mkdir -p artifacts
+          ./scripts/render_release_body.sh
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
@@ -496,39 +509,12 @@ jobs:
           draft: false
           prerelease: ${{ needs.prepare.outputs.is_rc }}
           generate_release_notes: true
+          body_path: artifacts/release-body.md
           files: |
             artifacts/starknet-devnet-x86_64-unknown-linux-gnu/starknet-devnet-x86_64-unknown-linux-gnu.tar.gz
             artifacts/starknet-devnet-aarch64-unknown-linux-gnu/starknet-devnet-aarch64-unknown-linux-gnu.tar.gz
             artifacts/starknet-devnet-x86_64-unknown-linux-musl/starknet-devnet-x86_64-unknown-linux-musl.tar.gz
             artifacts/starknet-devnet-x86_64-apple-darwin/starknet-devnet-x86_64-apple-darwin.tar.gz
             artifacts/starknet-devnet-aarch64-apple-darwin/starknet-devnet-aarch64-apple-darwin.tar.gz
-          body: |
-            # Starknet Devnet v${{ needs.prepare.outputs.version }}
-            
-            ## Installation
-            
-            ### Binary
-            Download the appropriate binary for your platform from the assets below.
-            
-            ### Docker
-            ```bash
-            # Pull by version
-            docker pull ${{ steps.config.outputs.docker_registry }}/${{ steps.config.outputs.docker_namespace }}/${{ steps.config.outputs.image_name }}:${{ needs.prepare.outputs.version }}
-            docker pull ${{ steps.config.outputs.docker_registry }}/${{ steps.config.outputs.docker_namespace }}/${{ steps.config.outputs.image_name }}:${{ needs.prepare.outputs.version }}-seed0
-            
-            # Pull by SHA
-            docker pull ${{ steps.config.outputs.docker_registry }}/${{ steps.config.outputs.docker_namespace }}/${{ steps.config.outputs.image_name }}:sha-${{ needs.prepare.outputs.sha }}
-            docker pull ${{ steps.config.outputs.docker_registry }}/${{ steps.config.outputs.docker_namespace }}/${{ steps.config.outputs.image_name }}:sha-${{ needs.prepare.outputs.sha }}-seed0
-            
-            ${{ needs.prepare.outputs.is_rc != 'true' && '# Pull latest versions' }}
-            ${{ needs.prepare.outputs.is_rc != 'true' && 'docker pull '}}${{ steps.config.outputs.docker_registry }}/${{ steps.config.outputs.docker_namespace }}/${{ steps.config.outputs.image_name }}:latest
-            ${{ needs.prepare.outputs.is_rc != 'true' && 'docker pull '}}${{ steps.config.outputs.docker_registry }}/${{ steps.config.outputs.docker_namespace }}/${{ steps.config.outputs.image_name }}:latest-seed0
-            ```
-            ${{ needs.prepare.outputs.is_rc == 'true' && '### Note\nLatest tags are not available for release candidates.' || '' }}
-            
-            ### Cargo
-            ```bash
-            cargo install starknet-devnet
-            ```
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/render_release_body.sh
+++ b/scripts/render_release_body.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Renders the Markdown body used for published GitHub releases.
+#
+# Required environment variables:
+#   VERSION          - e.g. "0.8.0-rc.3" or "0.8.0"
+#   SHA              - short commit SHA used for the Docker image tag
+#   IS_RC            - "true" if the version is a release candidate, else "false"
+#   DOCKER_REGISTRY  - e.g. "docker.io"
+#   DOCKER_NAMESPACE - e.g. "shardlabs"
+#   IMAGE_NAME       - e.g. "starknet-devnet-rs"
+#   OUTPUT_PATH      - path where the rendered body is written
+#
+# The script intentionally avoids every GitHub Actions `${{ ... && '...' }}`
+# ternary that produced the v0.8.0-rc.* malformed Docker notes (see issue #969)
+# by evaluating the RC branching as a plain shell `if/else`.
+
+set -euo pipefail
+
+: "${VERSION:?VERSION is required}"
+: "${SHA:?SHA is required}"
+: "${IS_RC:?IS_RC is required}"
+: "${DOCKER_REGISTRY:?DOCKER_REGISTRY is required}"
+: "${DOCKER_NAMESPACE:?DOCKER_NAMESPACE is required}"
+: "${IMAGE_NAME:?IMAGE_NAME is required}"
+: "${OUTPUT_PATH:?OUTPUT_PATH is required}"
+
+mkdir -p "$(dirname "$OUTPUT_PATH")"
+
+{
+  printf '# Starknet Devnet v%s\n\n' "$VERSION"
+  printf '## Installation\n\n'
+  printf '### Binary\n'
+  printf 'Download the appropriate binary for your platform from the assets below.\n\n'
+  printf '### Docker\n'
+  printf '```bash\n'
+  printf '# Pull by version\n'
+  printf 'docker pull %s/%s/%s:%s\n' "$DOCKER_REGISTRY" "$DOCKER_NAMESPACE" "$IMAGE_NAME" "$VERSION"
+  printf 'docker pull %s/%s/%s:%s-seed0\n\n' "$DOCKER_REGISTRY" "$DOCKER_NAMESPACE" "$IMAGE_NAME" "$VERSION"
+  printf '# Pull by SHA\n'
+  printf 'docker pull %s/%s/%s:sha-%s\n' "$DOCKER_REGISTRY" "$DOCKER_NAMESPACE" "$IMAGE_NAME" "$SHA"
+  printf 'docker pull %s/%s/%s:sha-%s-seed0\n' "$DOCKER_REGISTRY" "$DOCKER_NAMESPACE" "$IMAGE_NAME" "$SHA"
+  printf '```\n'
+
+  if [[ "$IS_RC" != "true" ]]; then
+    printf '\n# Pull latest versions\n'
+    printf 'docker pull %s/%s/%s:latest\n' "$DOCKER_REGISTRY" "$DOCKER_NAMESPACE" "$IMAGE_NAME"
+    printf 'docker pull %s/%s/%s:latest-seed0\n' "$DOCKER_REGISTRY" "$DOCKER_NAMESPACE" "$IMAGE_NAME"
+  else
+    printf '\n### Note\n\nLatest tags are not available for release candidates.\n'
+  fi
+
+  printf '\n### Cargo\n'
+  printf '```bash\n'
+  printf 'cargo install starknet-devnet\n'
+  printf '```\n'
+} > "$OUTPUT_PATH"


### PR DESCRIPTION
## Development related changes

Fix the malformed Docker installation instructions on the `v0.8.0-rc.0` … `v0.8.0-rc.3` GitHub releases (fixes #969).

The `Create GitHub Release` step built the body from inline `${{ ... && '...' }}` ternaries. GitHub evaluates both branches and stringifies the boolean, so for RC builds the rendered body contained literal `false` / `falsedocker.io` lines and a literal `\n` in the `### Note` paragraph. The Docker tags themselves were already correct — only the release body was malformed.

The four affected release bodies have been rewritten out of band via `gh release edit --notes-file`. This PR fixes the root cause:

- New `scripts/render_release_body.sh` builds the body from a shell template using a plain `if/else` for the RC branching.
- `Create GitHub Release` invokes the script and passes the output via `body_path` to `softprops/action-gh-release`.

## Checklist:

- [x] Checked the [contribution guide](https://github.com/starknet-io/starknet-devnet/blob/main/.github/CONTRIBUTING.md) and [agent guide](https://github.com/starknet-io/starknet-devnet/blob/main/AGENTS.md) where applicable
- [x] Applied formatting - `npm --prefix website ci && ./scripts/format.sh`
- [x] No routine validation errors - `./scripts/verify.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Ran integration tests - `./scripts/test_integration.sh`
- [x] Regenerated packaged UI assets - `npm --prefix web-ui run build:devnet`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/starknet-io/starknet-devnet/issues) resolvable by this PR - closes #969
- [x] Updated the tests if needed; all passing