### PR TITLE
refactor(tests): reduce integration test setup boilerplate

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -176,7 +176,7 @@ jobs:
           add-rust-environment-hash-key: "false"
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1.8.0
+        uses: foundry-rs/foundry-toolchain@v1.9.1
         with:
           version: nightly-5b7e4cb3c882b28f3c32ba580de27ce7381f415a
 

--- a/tests/integration/abort_blocks.rs
+++ b/tests/integration/abort_blocks.rs
@@ -52,10 +52,7 @@ async fn assert_txs_aborted(
 
 #[tokio::test]
 async fn abort_latest_block_with_hash() {
-    let devnet =
-        BackgroundDevnet::spawn_with_additional_args(&["--state-archive-capacity", "full"])
-            .await
-            .expect("Could not start Devnet");
+    let devnet = BackgroundDevnet::spawn_forkable_devnet().await.expect("Could not start Devnet");
 
     let genesis_block_hash = devnet.get_latest_block_with_tx_hashes().await.unwrap().block_hash;
 
@@ -86,10 +83,7 @@ async fn abort_latest_block_with_hash() {
 
 #[tokio::test]
 async fn abort_two_blocks() {
-    let devnet =
-        BackgroundDevnet::spawn_with_additional_args(&["--state-archive-capacity", "full"])
-            .await
-            .expect("Could not start Devnet");
+    let devnet = BackgroundDevnet::spawn_forkable_devnet().await.expect("Could not start Devnet");
 
     let first_block_hash = devnet.create_block().await.unwrap();
     let second_block_hash = devnet.create_block().await.unwrap();
@@ -103,10 +97,7 @@ async fn abort_two_blocks() {
 
 #[tokio::test]
 async fn abort_block_with_transaction() {
-    let devnet =
-        BackgroundDevnet::spawn_with_additional_args(&["--state-archive-capacity", "full"])
-            .await
-            .expect("Could not start Devnet");
+    let devnet = BackgroundDevnet::spawn_forkable_devnet().await.expect("Could not start Devnet");
 
     let mint_hash = devnet.mint(Felt::ONE, 100).await;
 
@@ -122,10 +113,7 @@ async fn abort_block_with_transaction() {
 
 #[tokio::test]
 async fn query_aborted_block_by_number_should_fail() {
-    let devnet =
-        BackgroundDevnet::spawn_with_additional_args(&["--state-archive-capacity", "full"])
-            .await
-            .expect("Could not start Devnet");
+    let devnet = BackgroundDevnet::spawn_forkable_devnet().await.expect("Could not start Devnet");
 
     let new_block_hash = devnet.create_block().await.unwrap();
     let aborted_blocks = devnet.abort_blocks(&BlockId::Hash(new_block_hash)).await.unwrap();
@@ -144,10 +132,7 @@ async fn query_aborted_block_by_number_should_fail() {
 
 #[tokio::test]
 async fn block_abortion_should_affect_state() {
-    let devnet =
-        BackgroundDevnet::spawn_with_additional_args(&["--state-archive-capacity", "full"])
-            .await
-            .expect("Could not start Devnet");
+    let devnet = BackgroundDevnet::spawn_forkable_devnet().await.expect("Could not start Devnet");
 
     // State setup
     devnet.mint(DUMMY_ADDRESS, DUMMY_AMOUNT).await;
@@ -187,10 +172,7 @@ async fn block_abortion_should_affect_state() {
 
 #[tokio::test]
 async fn block_abortion_should_affect_block_number() {
-    let devnet =
-        BackgroundDevnet::spawn_with_additional_args(&["--state-archive-capacity", "full"])
-            .await
-            .expect("Could not start Devnet");
+    let devnet = BackgroundDevnet::spawn_forkable_devnet().await.expect("Could not start Devnet");
 
     /// Assert `devnet` currently has `latest` and `pre_confirmed` as its block numbers.
     async fn assert_block_number(devnet: &BackgroundDevnet, latest: u64, pre_confirmed: u64) {
@@ -240,10 +222,7 @@ async fn abort_blocks_without_state_archive_capacity() {
 
 #[tokio::test]
 async fn abort_same_block_twice() {
-    let devnet =
-        BackgroundDevnet::spawn_with_additional_args(&["--state-archive-capacity", "full"])
-            .await
-            .expect("Could not start Devnet");
+    let devnet = BackgroundDevnet::spawn_forkable_devnet().await.expect("Could not start Devnet");
 
     let first_block_hash = devnet.create_block().await.unwrap();
     let second_block_hash = devnet.create_block().await.unwrap();
@@ -259,10 +238,7 @@ async fn abort_same_block_twice() {
 /// The purpose of this test to prevent a bug which overwrote the list of aborted blocks with newly
 /// aborted blocks, thus forgetting old abortions.
 async fn abort_same_block_twice_if_blocks_aborted_on_two_occasions() {
-    let devnet =
-        BackgroundDevnet::spawn_with_additional_args(&["--state-archive-capacity", "full"])
-            .await
-            .expect("Could not start Devnet");
+    let devnet = BackgroundDevnet::spawn_forkable_devnet().await.expect("Could not start Devnet");
 
     let first_block_hash = devnet.create_block().await.unwrap();
     let second_block_hash = devnet.create_block().await.unwrap();
@@ -282,9 +258,7 @@ async fn abort_same_block_twice_if_blocks_aborted_on_two_occasions() {
 #[tokio::test]
 async fn abort_block_after_fork() {
     let origin_devnet: BackgroundDevnet =
-        BackgroundDevnet::spawn_with_additional_args(&["--state-archive-capacity", "full"])
-            .await
-            .expect("Could not start Devnet");
+        BackgroundDevnet::spawn_forkable_devnet().await.expect("Could not start Devnet");
 
     let fork_devnet = origin_devnet.fork_with_full_state_archive().await.unwrap();
 
@@ -300,10 +274,7 @@ async fn abort_block_after_fork() {
 
 #[tokio::test]
 async fn abort_latest_blocks() {
-    let devnet =
-        BackgroundDevnet::spawn_with_additional_args(&["--state-archive-capacity", "full"])
-            .await
-            .expect("Could not start Devnet");
+    let devnet = BackgroundDevnet::spawn_forkable_devnet().await.expect("Could not start Devnet");
 
     for _ in 0..3 {
         devnet.create_block().await.unwrap();

--- a/tests/integration/accepting_blocks_on_l1.rs
+++ b/tests/integration/accepting_blocks_on_l1.rs
@@ -450,10 +450,7 @@ async fn should_fail_if_accepting_pre_confirmed() {
 
 #[tokio::test]
 async fn should_fail_if_accepting_rejected() {
-    let devnet =
-        BackgroundDevnet::spawn_with_additional_args(&["--state-archive-capacity", "full"])
-            .await
-            .unwrap();
+    let devnet = BackgroundDevnet::spawn_forkable_devnet().await.unwrap();
 
     send_dummy_tx(&devnet).await;
     let aborted_blocks = devnet.abort_blocks(&BlockId::Tag(BlockTag::Latest)).await.unwrap();

--- a/tests/integration/account_impersonation.rs
+++ b/tests/integration/account_impersonation.rs
@@ -26,7 +26,7 @@ const AMOUNT_TO_TRANSFER: Felt = Felt::from_raw([
 async fn get_account_for_impersonation_and_private_key(
     devnet: &BackgroundDevnet,
 ) -> (Felt, LocalWallet) {
-    let (_, account_address) = devnet.get_first_predeployed_account().await;
+    let (_, account_address) = devnet.get_first_predeployed_account_credentials().await;
     (
         account_address,
         LocalWallet::from_signing_key(SigningKey::from_secret_scalar(
@@ -90,7 +90,7 @@ async fn test_account_impersonation_have_to_return_an_error_when_in_restrictive_
 #[tokio::test]
 async fn test_impersonated_of_a_predeployed_account_account_can_send_transaction() {
     let devnet = BackgroundDevnet::spawn_forkable_devnet().await.expect("Could not start Devnet");
-    let (_, account_address) = devnet.get_first_predeployed_account().await;
+    let (_, account_address) = devnet.get_first_predeployed_account_credentials().await;
 
     test_invoke_transaction(&devnet, &[ImpersonationAction::ImpersonateAccount(account_address)])
         .await
@@ -125,7 +125,7 @@ async fn test_auto_impersonate_allows_user_to_send_transactions() {
 async fn test_impersonate_account_and_then_stop_impersonate_have_to_return_an_error_of_invalid_signature()
  {
     let origin_devnet = &BackgroundDevnet::spawn_forkable_devnet().await.unwrap();
-    let (_, account_address) = origin_devnet.get_first_predeployed_account().await;
+    let (_, account_address) = origin_devnet.get_first_predeployed_account_credentials().await;
     let invoke_txn_err = test_invoke_transaction(
         origin_devnet,
         &[

--- a/tests/integration/account_selection.rs
+++ b/tests/integration/account_selection.rs
@@ -48,7 +48,7 @@ async fn correct_artifact_test_body(
 ) -> Result<(), anyhow::Error> {
     let devnet = BackgroundDevnet::spawn_with_additional_args(devnet_args).await?;
 
-    let (_, account_address) = devnet.get_first_predeployed_account().await;
+    let (_, account_address) = devnet.get_first_predeployed_account_credentials().await;
     let retrieved_class_hash = devnet
         .json_rpc_client
         .get_class_hash_at(BlockId::Tag(BlockTag::Latest), account_address)
@@ -220,7 +220,7 @@ async fn can_declare_deploy_invoke_using_predeployed_cairo1() {
     let cli_args = ["--account-class", "cairo1"];
     let devnet = BackgroundDevnet::spawn_with_additional_args(&cli_args).await.unwrap();
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
+    let (signer, account_address) = devnet.get_first_predeployed_account_credentials().await;
     can_declare_deploy_invoke_cairo1_using_account(&devnet, &signer, account_address).await;
 }
 
@@ -229,7 +229,7 @@ async fn can_declare_deploy_invoke_using_predeployed_custom() {
     let cli_args = ["--account-class-custom", CAIRO_1_ACCOUNT_CONTRACT_SIERRA_PATH];
     let devnet = BackgroundDevnet::spawn_with_additional_args(&cli_args).await.unwrap();
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
+    let (signer, account_address) = devnet.get_first_predeployed_account_credentials().await;
     can_declare_deploy_invoke_cairo1_using_account(&devnet, &signer, account_address).await;
 }
 
@@ -254,7 +254,7 @@ async fn assert_supports_isrc6(
 #[tokio::test]
 async fn test_interface_support_of_predeployed_account() {
     let devnet = BackgroundDevnet::spawn().await.unwrap();
-    let (_, account_address) = devnet.get_first_predeployed_account().await;
+    let (_, account_address) = devnet.get_first_predeployed_account_credentials().await;
 
     assert_supports_isrc6(&devnet, account_address).await.unwrap();
 }

--- a/tests/integration/advancing_time.rs
+++ b/tests/integration/advancing_time.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time;
 
 use serde_json::json;
-use starknet_rs_accounts::{Account, AccountError, ExecutionEncoding, SingleOwnerAccount};
+use starknet_rs_accounts::{Account, AccountError};
 use starknet_rs_core::types::{
     BlockId, BlockTag, Call, Felt, FunctionCall, StarknetError, TransactionExecutionStatus,
     TransactionStatus,
@@ -11,7 +11,6 @@ use starknet_rs_core::utils::{get_selector_from_name, get_udc_deployed_address};
 use starknet_rs_providers::{Provider, ProviderError};
 
 use crate::common::background_devnet::BackgroundDevnet;
-use crate::common::constants;
 use crate::common::utils::{
     UniqueAutoDeletableFile, assert_contains, declare_v3_deploy_v3, extract_message_error,
     extract_nested_error, get_block_reader_contract_artifacts,
@@ -50,14 +49,7 @@ fn assert_eq_with_buffer(val1: u64, val2: u64) {
 }
 
 pub async fn setup_timestamp_contract(devnet: &BackgroundDevnet) -> Felt {
-    let (signer, address) = devnet.get_first_predeployed_account().await;
-    let predeployed_account = SingleOwnerAccount::new(
-        devnet.clone_provider(),
-        signer,
-        address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let predeployed_account = devnet.get_first_predeployed_account_owned().await;
 
     // declare
     let (cairo_1_contract, casm_class_hash) = get_block_reader_contract_artifacts();
@@ -604,14 +596,7 @@ async fn correct_pre_confirmed_block_timestamp_after_setting() {
 async fn tx_resource_estimation_fails_unless_time_incremented() {
     let devnet = BackgroundDevnet::spawn().await.unwrap();
 
-    let (signer, address) = devnet.get_first_predeployed_account().await;
-    let account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let account = devnet.get_first_predeployed_account().await;
 
     let (contract_class, casm_hash) = get_timestamp_asserter_contract_artifacts();
 
@@ -657,14 +642,7 @@ async fn tx_resource_estimation_fails_unless_time_incremented() {
 async fn tx_execution_fails_unless_time_incremented() {
     let devnet = BackgroundDevnet::spawn().await.unwrap();
 
-    let (signer, address) = devnet.get_first_predeployed_account().await;
-    let account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let account = devnet.get_first_predeployed_account().await;
 
     let (contract_class, casm_hash) = get_timestamp_asserter_contract_artifacts();
 

--- a/tests/integration/advancing_time_on_fork.rs
+++ b/tests/integration/advancing_time_on_fork.rs
@@ -18,14 +18,7 @@ async fn tx_resource_estimation_fails_on_forked_devnet_with_impersonation_unless
 {
     let origin_devnet = BackgroundDevnet::spawn_forkable_devnet().await.unwrap();
 
-    let (signer, address) = origin_devnet.get_first_predeployed_account().await;
-    let origin_account = SingleOwnerAccount::new(
-        &origin_devnet.json_rpc_client,
-        signer,
-        address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let origin_account = origin_devnet.get_first_predeployed_account().await;
 
     let (contract_class, casm_hash) = get_timestamp_asserter_contract_artifacts();
 
@@ -42,7 +35,7 @@ async fn tx_resource_estimation_fails_on_forked_devnet_with_impersonation_unless
     let fork_account = SingleOwnerAccount::new(
         &forked_devnet.json_rpc_client,
         LocalWallet::from(SigningKey::from_secret_scalar(Felt::TWO)),
-        address,
+        origin_account.address(),
         constants::CHAIN_ID,
         ExecutionEncoding::New,
     );
@@ -89,14 +82,7 @@ async fn tx_resource_estimation_fails_on_forked_devnet_with_impersonation_unless
 async fn tx_execution_fails_on_forked_devnet_with_impersonation_unless_time_incremented() {
     let origin_devnet = BackgroundDevnet::spawn_forkable_devnet().await.unwrap();
 
-    let (signer, address) = origin_devnet.get_first_predeployed_account().await;
-    let origin_account = SingleOwnerAccount::new(
-        &origin_devnet.json_rpc_client,
-        signer,
-        address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let origin_account = origin_devnet.get_first_predeployed_account().await;
 
     let (contract_class, casm_hash) = get_timestamp_asserter_contract_artifacts();
 
@@ -113,7 +99,7 @@ async fn tx_execution_fails_on_forked_devnet_with_impersonation_unless_time_incr
     let fork_account = SingleOwnerAccount::new(
         &forked_devnet.json_rpc_client,
         LocalWallet::from(SigningKey::from_secret_scalar(Felt::TWO)),
-        address,
+        origin_account.address(),
         constants::CHAIN_ID,
         ExecutionEncoding::New,
     );

--- a/tests/integration/blocks_generation.rs
+++ b/tests/integration/blocks_generation.rs
@@ -187,7 +187,7 @@ async fn assert_balance(
 }
 
 async fn assert_get_nonce(devnet: &BackgroundDevnet) -> Result<(), anyhow::Error> {
-    let (_, account_address) = devnet.get_first_predeployed_account().await;
+    let (_, account_address) = devnet.get_first_predeployed_account_credentials().await;
 
     let pre_confirmed_block_nonce = devnet
         .json_rpc_client
@@ -201,7 +201,7 @@ async fn assert_get_nonce(devnet: &BackgroundDevnet) -> Result<(), anyhow::Error
 }
 
 async fn assert_get_storage_at(devnet: &BackgroundDevnet) -> Result<(), anyhow::Error> {
-    let (_, account_address) = devnet.get_first_predeployed_account().await;
+    let (_, account_address) = devnet.get_first_predeployed_account_credentials().await;
     let key = Felt::ZERO;
 
     let pre_confirmed_block_storage = devnet
@@ -220,7 +220,7 @@ async fn assert_get_storage_at(devnet: &BackgroundDevnet) -> Result<(), anyhow::
 }
 
 async fn assert_get_class_hash_at(devnet: &BackgroundDevnet) -> Result<(), anyhow::Error> {
-    let (_, account_address) = devnet.get_first_predeployed_account().await;
+    let (_, account_address) = devnet.get_first_predeployed_account_credentials().await;
 
     let pre_confirmed_block_class_hash = devnet
         .json_rpc_client
@@ -318,7 +318,7 @@ async fn blocks_on_demand_declarations() {
     let devnet_args = ["--block-generation-on", "demand"];
     let devnet = BackgroundDevnet::spawn_with_additional_args(&devnet_args).await.unwrap();
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
+    let (signer, account_address) = devnet.get_first_predeployed_account_credentials().await;
     let mut predeployed_account = SingleOwnerAccount::new(
         devnet.clone_provider(),
         signer.clone(),
@@ -405,7 +405,7 @@ async fn blocks_on_demand_invoke_and_call() {
 
     let mut tx_hashes = Vec::new();
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
+    let (signer, account_address) = devnet.get_first_predeployed_account_credentials().await;
     let mut predeployed_account = SingleOwnerAccount::new(
         devnet.clone_provider(),
         signer.clone(),
@@ -633,7 +633,7 @@ async fn get_class_hash_at_block_on_demand() {
 #[tokio::test]
 async fn get_data_by_specifying_latest_block_hash_and_number() {
     let devnet = BackgroundDevnet::spawn().await.unwrap();
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
+    let (signer, account_address) = devnet.get_first_predeployed_account_credentials().await;
     let latest_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
     let block_ids =
         [BlockId::Hash(latest_block.block_hash), BlockId::Number(latest_block.block_number)];

--- a/tests/integration/call.rs
+++ b/tests/integration/call.rs
@@ -1,4 +1,3 @@
-use starknet_rs_accounts::SingleOwnerAccount;
 use starknet_rs_core::types::{
     BlockId, BlockTag, ContractErrorData, Felt, FunctionCall, StarknetError,
 };
@@ -102,14 +101,7 @@ async fn calling_nonexistent_cairo1_contract_method() {
 async fn call_panicking_method() {
     let devnet = BackgroundDevnet::spawn().await.unwrap();
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        account_address,
-        devnet.json_rpc_client.chain_id().await.unwrap(),
-        starknet_rs_accounts::ExecutionEncoding::New,
-    );
+    let account = devnet.get_first_predeployed_account().await;
 
     let (contract_class, casm_hash) =
         get_flattened_sierra_contract_and_casm_hash(CAIRO_1_PANICKING_CONTRACT_SIERRA_PATH);

--- a/tests/integration/common/background_devnet.rs
+++ b/tests/integration/common/background_devnet.rs
@@ -8,6 +8,7 @@ use base64::Engine;
 use lazy_static::lazy_static;
 use reqwest::{Client, StatusCode};
 use serde_json::json;
+use starknet_rs_accounts::{ExecutionEncoding, SingleOwnerAccount};
 use starknet_rs_core::types::{
     BlockId, BlockTag, BlockWithTxHashes, BlockWithTxs, BroadcastedInvokeTransaction, Felt,
     FunctionCall, MaybePreConfirmedBlockWithTxHashes, MaybePreConfirmedBlockWithTxs,
@@ -43,6 +44,9 @@ pub struct BackgroundDevnet {
     pub url: String,
     rpc_url: Url,
 }
+
+pub type PredeployedAccount<'a> = SingleOwnerAccount<&'a JsonRpcClient<HttpTransport>, LocalWallet>;
+pub type OwnedPredeployedAccount = SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>;
 
 #[derive(Debug, Clone)]
 pub struct ProveTransactionResult {
@@ -443,8 +447,63 @@ impl BackgroundDevnet {
         }
     }
 
-    /// This method returns the private key and the address of the first predeployed account
-    pub async fn get_first_predeployed_account(&self) -> (LocalWallet, Felt) {
+    /// Returns an account connected to this Devnet's provider using the first predeployed account.
+    pub async fn get_first_predeployed_account(&self) -> PredeployedAccount<'_> {
+        self.get_first_predeployed_account_with_encoding(ExecutionEncoding::New).await
+    }
+
+    /// Returns the first predeployed account with an owned provider, allowing the account to be
+    /// moved into tasks or other `'static` contexts.
+    pub async fn get_first_predeployed_account_owned(&self) -> OwnedPredeployedAccount {
+        let (signer, account_address) = self.get_first_predeployed_account_credentials().await;
+        let chain_id = self.json_rpc_client.chain_id().await.unwrap();
+
+        SingleOwnerAccount::new(
+            self.clone_provider(),
+            signer,
+            account_address,
+            chain_id,
+            ExecutionEncoding::New,
+        )
+    }
+
+    /// Returns the connected account and a copy of its signer for tests that construct and sign
+    /// RPC transactions manually.
+    pub async fn get_first_predeployed_account_with_signer(
+        &self,
+    ) -> (PredeployedAccount<'_>, LocalWallet) {
+        self.get_first_predeployed_account_with_signer_and_encoding(ExecutionEncoding::New).await
+    }
+
+    /// Returns an account connected to this Devnet's provider using the requested execution
+    /// encoding.
+    pub async fn get_first_predeployed_account_with_encoding(
+        &self,
+        execution_encoding: ExecutionEncoding,
+    ) -> PredeployedAccount<'_> {
+        self.get_first_predeployed_account_with_signer_and_encoding(execution_encoding).await.0
+    }
+
+    /// Returns the connected account and signer using the requested execution encoding.
+    pub async fn get_first_predeployed_account_with_signer_and_encoding(
+        &self,
+        execution_encoding: ExecutionEncoding,
+    ) -> (PredeployedAccount<'_>, LocalWallet) {
+        let (signer, account_address) = self.get_first_predeployed_account_credentials().await;
+        let chain_id = self.json_rpc_client.chain_id().await.unwrap();
+
+        let account = SingleOwnerAccount::new(
+            &self.json_rpc_client,
+            signer.clone(),
+            account_address,
+            chain_id,
+            execution_encoding,
+        );
+        (account, signer)
+    }
+
+    /// Returns the signer and address of the first predeployed account.
+    pub async fn get_first_predeployed_account_credentials(&self) -> (LocalWallet, Felt) {
         let predeployed_accounts_json =
             self.send_custom_rpc("devnet_getPredeployedAccounts", json!({})).await.unwrap();
 

--- a/tests/integration/common/utils.rs
+++ b/tests/integration/common/utils.rs
@@ -12,8 +12,7 @@ use serde_json::json;
 use starknet_api::contract_class::compiled_class_hash::{HashVersion, HashableCompiledClass};
 use starknet_core::CasmContractClass;
 use starknet_rs_accounts::{
-    Account, AccountFactory, ArgentAccountFactory, ExecutionEncoding, OpenZeppelinAccountFactory,
-    SingleOwnerAccount,
+    Account, AccountFactory, ArgentAccountFactory, OpenZeppelinAccountFactory, SingleOwnerAccount,
 };
 use starknet_rs_contract::{ContractFactory, UdcSelector};
 use starknet_rs_core::types::contract::SierraClass;
@@ -35,8 +34,8 @@ use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 
 use super::background_devnet::BackgroundDevnet;
 use super::constants::{
-    CAIRO_1_ACCOUNT_CONTRACT_SIERRA_HASH, CAIRO_1_CONTRACT_PATH, CHAIN_ID,
-    ETH_ERC20_CONTRACT_ADDRESS, UDC_CONTRACT_ADDRESS,
+    CAIRO_1_ACCOUNT_CONTRACT_SIERRA_HASH, CAIRO_1_CONTRACT_PATH, ETH_ERC20_CONTRACT_ADDRESS,
+    UDC_CONTRACT_ADDRESS,
 };
 use super::safe_child::SafeChild;
 use crate::common::errors::RpcError;
@@ -152,14 +151,7 @@ pub struct ProofBearingTransactionDetails {
 pub async fn create_proof_bearing_transaction(
     devnet: &BackgroundDevnet,
 ) -> ProofBearingTransactionDetails {
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let mut account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        account_address,
-        CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let mut account = devnet.get_first_predeployed_account().await;
     account.set_block_id(BlockId::Tag(BlockTag::Latest));
 
     let tx_calls = vec![Call {
@@ -170,7 +162,7 @@ pub async fn create_proof_bearing_transaction(
 
     let tx_nonce = devnet
         .json_rpc_client
-        .get_nonce(BlockId::Tag(BlockTag::Latest), account_address)
+        .get_nonce(BlockId::Tag(BlockTag::Latest), account.address())
         .await
         .unwrap();
 

--- a/tests/integration/deploy.rs
+++ b/tests/integration/deploy.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use starknet_core::constants::UDC_CONTRACT_CLASS_HASH;
-use starknet_rs_accounts::{Account, AccountError, ExecutionEncoding, SingleOwnerAccount};
+use starknet_rs_accounts::{Account, AccountError};
 use starknet_rs_core::types::{
     Call, ContractExecutionError, Felt, StarknetError, TransactionExecutionErrorData,
 };
@@ -10,7 +10,7 @@ use starknet_rs_providers::ProviderError;
 
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::constants::{
-    self, CAIRO_1_ACCOUNT_CONTRACT_SIERRA_HASH, UDC_CONTRACT_ADDRESS, UDC_LEGACY_CONTRACT_ADDRESS,
+    CAIRO_1_ACCOUNT_CONTRACT_SIERRA_HASH, UDC_CONTRACT_ADDRESS, UDC_LEGACY_CONTRACT_ADDRESS,
 };
 use crate::common::utils::{
     assert_contains, assert_tx_succeeded_accepted, extract_message_error, extract_nested_error,
@@ -23,14 +23,7 @@ use crate::common::utils::{
 async fn double_deployment_not_allowed() {
     let devnet = BackgroundDevnet::spawn().await.unwrap();
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let account = devnet.get_first_predeployed_account().await;
 
     // declare
     let (contract_class, casm_hash) = get_simple_contract_artifacts();
@@ -87,14 +80,7 @@ async fn double_deployment_not_allowed() {
 async fn cannot_deploy_undeclared_class() {
     let devnet = BackgroundDevnet::spawn().await.unwrap();
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let account = devnet.get_first_predeployed_account().await;
 
     // skip declaration
     let (contract_class, _) = get_simple_contract_artifacts();
@@ -116,14 +102,7 @@ async fn cannot_deploy_undeclared_class() {
 async fn test_all_udc_deployment_methods_supported() {
     let devnet = BackgroundDevnet::spawn().await.unwrap();
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let account = devnet.get_first_predeployed_account().await;
 
     // declare
     let (contract_class, casm_hash) = get_simple_contract_artifacts();

--- a/tests/integration/dump_and_load.rs
+++ b/tests/integration/dump_and_load.rs
@@ -6,7 +6,6 @@ use starknet_rs_providers::Provider;
 
 use crate::assert_eq_prop;
 use crate::common::background_devnet::BackgroundDevnet;
-use crate::common::constants;
 use crate::common::utils::{
     FeeUnit, UniqueAutoDeletableFile, new_contract_factory, send_ctrl_c_signal_and_wait,
 };
@@ -16,7 +15,7 @@ static DUMMY_AMOUNT: u128 = 1;
 
 use std::sync::Arc;
 
-use starknet_rs_accounts::{Account, ExecutionEncoding, SingleOwnerAccount};
+use starknet_rs_accounts::Account;
 use starknet_rs_core::types::{DeclareTransaction, Felt, InvokeTransaction, Transaction};
 
 use crate::common::utils::get_events_contract_artifacts;
@@ -221,14 +220,7 @@ async fn declare_deploy() {
     .await
     .expect("Could not start Devnet");
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let predeployed_account = SingleOwnerAccount::new(
-        devnet.clone_provider(),
-        signer,
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let predeployed_account = devnet.get_first_predeployed_account_owned().await;
 
     let (cairo_1_contract, casm_class_hash) = get_events_contract_artifacts();
 

--- a/tests/integration/estimate_fee.rs
+++ b/tests/integration/estimate_fee.rs
@@ -143,7 +143,7 @@ async fn estimate_fee_of_declare_v3() {
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
 
     // get account
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
+    let (signer, account_address) = devnet.get_first_predeployed_account_credentials().await;
 
     // get class
     let (flattened_contract_artifact, casm_hash) =
@@ -212,14 +212,7 @@ async fn estimate_fee_of_invoke() {
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
 
     // get account
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let account = Arc::new(SingleOwnerAccount::new(
-        devnet.clone_provider(),
-        signer,
-        account_address,
-        CHAIN_ID,
-        ExecutionEncoding::New,
-    ));
+    let account = Arc::new(devnet.get_first_predeployed_account_owned().await);
 
     // get class
     let (contract_artifact, casm_hash) = get_simple_contract_artifacts();
@@ -305,14 +298,7 @@ async fn message_available_if_estimation_reverts() {
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
 
     // get account
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let account = Arc::new(SingleOwnerAccount::new(
-        devnet.clone_provider(),
-        signer,
-        account_address,
-        CHAIN_ID,
-        ExecutionEncoding::New,
-    ));
+    let account = Arc::new(devnet.get_first_predeployed_account_owned().await);
 
     // get class
     let (flattened_contract_artifact, casm_hash) =
@@ -377,14 +363,7 @@ async fn using_query_version_if_estimating() {
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
 
     // get account
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let account = Arc::new(SingleOwnerAccount::new(
-        devnet.clone_provider(),
-        signer,
-        account_address,
-        CHAIN_ID,
-        ExecutionEncoding::New,
-    ));
+    let account = Arc::new(devnet.get_first_predeployed_account_owned().await);
 
     // get class
     let (flattened_contract_artifact, casm_hash) =
@@ -499,14 +478,9 @@ async fn estimate_fee_of_multiple_txs() {
         .expect("Could not start Devnet");
 
     // get account
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let mut account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer.clone(),
-        account_address,
-        devnet.json_rpc_client.chain_id().await.unwrap(),
-        ExecutionEncoding::Legacy,
-    );
+    let (mut account, signer) = devnet
+        .get_first_predeployed_account_with_signer_and_encoding(ExecutionEncoding::Legacy)
+        .await;
     account.set_block_id(BlockId::Tag(BlockTag::Latest));
 
     // get class
@@ -541,7 +515,7 @@ async fn estimate_fee_of_multiple_txs() {
                 BroadcastedTransaction::Declare(BroadcastedDeclareTransactionV3 {
                     signature: vec![declaration_signature.r, declaration_signature.s],
                     nonce: declaration_nonce,
-                    sender_address: account_address,
+                    sender_address: account.address(),
                     contract_class,
                     is_query: query_only,
                     compiled_class_hash: casm_hash,
@@ -588,14 +562,7 @@ async fn estimate_fee_of_multiple_txs() {
 #[tokio::test]
 async fn estimate_fee_of_multiple_txs_with_second_failing() {
     let devnet = BackgroundDevnet::spawn().await.unwrap();
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer.clone(),
-        account_address,
-        CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let (account, signer) = devnet.get_first_predeployed_account_with_signer().await;
 
     let non_existent_selector = get_selector_from_name("nonExistentMethod").unwrap();
 
@@ -655,14 +622,7 @@ async fn estimate_fee_of_multiple_failing_txs_should_return_index_of_the_first_f
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start devnet");
 
     // get account
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let mut account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer.clone(),
-        account_address,
-        devnet.json_rpc_client.chain_id().await.unwrap(),
-        ExecutionEncoding::New,
-    );
+    let mut account = devnet.get_first_predeployed_account().await;
 
     account.set_block_id(BlockId::Tag(BlockTag::Latest));
 
@@ -699,7 +659,7 @@ async fn estimate_fee_of_multiple_failing_txs_should_return_index_of_the_first_f
         .estimate_fee(
             [
                 BroadcastedTransaction::Declare(BroadcastedDeclareTransactionV3 {
-                    sender_address: account_address,
+                    sender_address: account.address(),
                     compiled_class_hash: casm_hash,
                     signature: vec![],
                     nonce: Felt::ZERO,
@@ -714,7 +674,7 @@ async fn estimate_fee_of_multiple_failing_txs_should_return_index_of_the_first_f
                 }),
                 BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction {
                     broadcasted_invoke_txn_v3: BroadcastedInvokeTransactionV3 {
-                        sender_address: account_address,
+                        sender_address: account.address(),
                         calldata,
                         signature: vec![],
                         nonce: Felt::ONE,

--- a/tests/integration/estimate_message_fee.rs
+++ b/tests/integration/estimate_message_fee.rs
@@ -1,12 +1,12 @@
 use std::sync::Arc;
 
-use starknet_rs_accounts::{Account, ExecutionEncoding, SingleOwnerAccount};
+use starknet_rs_accounts::Account;
 use starknet_rs_core::types::{BlockId, BlockTag, EthAddress, Felt, MsgFromL1, StarknetError};
 use starknet_rs_core::utils::{UdcUniqueness, get_udc_deployed_address};
 use starknet_rs_providers::{Provider, ProviderError};
 
 use crate::common::background_devnet::BackgroundDevnet;
-use crate::common::constants::{CHAIN_ID, L1_HANDLER_SELECTOR, MESSAGING_WHITELISTED_L1_CONTRACT};
+use crate::common::constants::{L1_HANDLER_SELECTOR, MESSAGING_WHITELISTED_L1_CONTRACT};
 use crate::common::utils::{get_messaging_contract_artifacts, new_contract_factory};
 
 #[tokio::test]
@@ -14,14 +14,7 @@ async fn estimate_message_fee() {
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
 
     // get account
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let account = Arc::new(SingleOwnerAccount::new(
-        devnet.clone_provider(),
-        signer,
-        account_address,
-        CHAIN_ID,
-        ExecutionEncoding::New,
-    ));
+    let account = Arc::new(devnet.get_first_predeployed_account_owned().await);
 
     // get class
     let (contract_artifact, casm_hash) = get_messaging_contract_artifacts();
@@ -92,10 +85,7 @@ async fn estimate_message_fee_contract_not_found() {
 
 #[tokio::test]
 async fn estimate_message_fee_block_not_found() {
-    let devnet =
-        BackgroundDevnet::spawn_with_additional_args(&["--state-archive-capacity", "full"])
-            .await
-            .expect("Could not start Devnet");
+    let devnet = BackgroundDevnet::spawn_forkable_devnet().await.expect("Could not start Devnet");
 
     let err = devnet
         .json_rpc_client

--- a/tests/integration/fork.rs
+++ b/tests/integration/fork.rs
@@ -84,10 +84,7 @@ async fn test_getting_non_existent_block_from_origin() {
 
 #[tokio::test]
 async fn test_forking_local_genesis_block() {
-    let origin_devnet =
-        BackgroundDevnet::spawn_with_additional_args(&["--state-archive-capacity", "full"])
-            .await
-            .unwrap();
+    let origin_devnet = BackgroundDevnet::spawn_forkable_devnet().await.unwrap();
     let origin_devnet_genesis_block =
         &origin_devnet.get_latest_block_with_tx_hashes().await.unwrap();
 
@@ -164,19 +161,9 @@ async fn test_getting_cairo0_class_from_fork() {
 
 #[tokio::test]
 async fn test_getting_cairo1_class_from_origin_and_fork() {
-    let origin_devnet =
-        BackgroundDevnet::spawn_with_additional_args(&["--state-archive-capacity", "full"])
-            .await
-            .unwrap();
+    let origin_devnet = BackgroundDevnet::spawn_forkable_devnet().await.unwrap();
 
-    let (signer, account_address) = origin_devnet.get_first_predeployed_account().await;
-    let predeployed_account = SingleOwnerAccount::new(
-        &origin_devnet.json_rpc_client,
-        signer.clone(),
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let predeployed_account = origin_devnet.get_first_predeployed_account().await;
 
     let (contract_class, casm_hash) = get_simple_contract_artifacts();
 
@@ -216,7 +203,7 @@ async fn test_getting_cairo1_class_from_origin_and_fork() {
 async fn test_origin_declare_deploy_fork_invoke() {
     let origin_devnet = BackgroundDevnet::spawn_forkable_devnet().await.unwrap();
 
-    let (signer, account_address) = origin_devnet.get_first_predeployed_account().await;
+    let (signer, account_address) = origin_devnet.get_first_predeployed_account_credentials().await;
     let predeployed_account = Arc::new(SingleOwnerAccount::new(
         origin_devnet.clone_provider(),
         signer.clone(),
@@ -309,7 +296,7 @@ async fn test_deploying_account_with_class_not_present_on_origin() {
 
     let fork_devnet = origin_devnet.fork().await.unwrap();
 
-    let (signer, _) = origin_devnet.get_first_predeployed_account().await;
+    let (signer, _) = origin_devnet.get_first_predeployed_account_credentials().await;
 
     let nonexistent_class_hash = Felt::from_hex_unchecked("0x123");
     let factory = OpenZeppelinAccountFactory::new(
@@ -353,7 +340,7 @@ async fn test_deploying_account_with_class_present_on_origin() {
     .await
     .unwrap();
 
-    let (signer, _) = origin_devnet.get_first_predeployed_account().await;
+    let (signer, _) = origin_devnet.get_first_predeployed_account_credentials().await;
 
     // fork, but first create a forkable origin block
     origin_devnet.create_block().await.unwrap();
@@ -395,7 +382,7 @@ async fn test_get_nonce_if_contract_deployed_on_origin() {
     let origin_devnet = BackgroundDevnet::spawn_forkable_devnet().await.unwrap();
     let fork_devnet = origin_devnet.fork().await.unwrap();
 
-    let (_, account_address) = origin_devnet.get_first_predeployed_account().await;
+    let (_, account_address) = origin_devnet.get_first_predeployed_account_credentials().await;
 
     let nonce = fork_devnet
         .json_rpc_client
@@ -426,7 +413,7 @@ async fn test_get_storage_if_contract_deployed_on_origin() {
     let origin_devnet = BackgroundDevnet::spawn_forkable_devnet().await.unwrap();
     let fork_devnet = origin_devnet.fork().await.unwrap();
 
-    let (signer, account_address) = origin_devnet.get_first_predeployed_account().await;
+    let (signer, account_address) = origin_devnet.get_first_predeployed_account_credentials().await;
 
     let dummy_key = Felt::ONE;
     let dummy_value = fork_devnet
@@ -452,14 +439,7 @@ async fn test_deploying_on_origin_calling_on_fork() {
     let origin_devnet = BackgroundDevnet::spawn_forkable_devnet().await.unwrap();
 
     // obtain account for deployment
-    let (signer, account_address) = origin_devnet.get_first_predeployed_account().await;
-    let predeployed_account = SingleOwnerAccount::new(
-        &origin_devnet.json_rpc_client,
-        signer.clone(),
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let predeployed_account = origin_devnet.get_first_predeployed_account().await;
 
     let (contract_class, casm_hash) = get_simple_contract_artifacts();
 
@@ -489,14 +469,7 @@ async fn test_deploying_on_origin_calling_on_fork() {
 async fn changes_in_origin_after_forking_block_should_not_affect_fork_state() {
     let origin_devnet = BackgroundDevnet::spawn_forkable_devnet().await.unwrap();
 
-    let (signer, account_address) = origin_devnet.get_first_predeployed_account().await;
-    let predeployed_account = SingleOwnerAccount::new(
-        &origin_devnet.json_rpc_client,
-        signer.clone(),
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let predeployed_account = origin_devnet.get_first_predeployed_account().await;
 
     let (contract_class, casm_hash) = get_simple_contract_artifacts();
 
@@ -626,14 +599,7 @@ async fn test_block_count_increased() {
 async fn test_block_count_increased_on_state() {
     let origin_devnet = BackgroundDevnet::spawn_forkable_devnet().await.unwrap();
 
-    let (signer, account_address) = origin_devnet.get_first_predeployed_account().await;
-    let predeployed_account = SingleOwnerAccount::new(
-        &origin_devnet.json_rpc_client,
-        signer.clone(),
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let predeployed_account = origin_devnet.get_first_predeployed_account().await;
 
     let (contract_class, casm_hash) = get_block_reader_contract_artifacts();
 

--- a/tests/integration/gas_modification.rs
+++ b/tests/integration/gas_modification.rs
@@ -60,7 +60,7 @@ async fn set_gas_scenario(
     expected_chain_id: Felt,
 ) -> Result<(), anyhow::Error> {
     // get account
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
+    let (signer, account_address) = devnet.get_first_predeployed_account_credentials().await;
     let account = SingleOwnerAccount::new(
         devnet.clone_provider(),
         signer.clone(),
@@ -349,7 +349,7 @@ async fn set_gas_check_blocks() {
 #[tokio::test]
 async fn unsuccessful_declare_set_gas_successful_declare() {
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
+    let (signer, account_address) = devnet.get_first_predeployed_account_credentials().await;
     let predeployed_account = Arc::new(SingleOwnerAccount::new(
         devnet.clone_provider(),
         signer.clone(),

--- a/tests/integration/get_class.rs
+++ b/tests/integration/get_class.rs
@@ -45,7 +45,7 @@ async fn test_getting_class() {
 async fn test_getting_class_of_declared_cairo1_contract() {
     let devnet = BackgroundDevnet::spawn().await.unwrap();
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
+    let (signer, account_address) = devnet.get_first_predeployed_account_credentials().await;
     let predeployed_account = Arc::new(SingleOwnerAccount::new(
         devnet.clone_provider(),
         signer.clone(),
@@ -94,7 +94,7 @@ async fn test_getting_class_with_blocks_on_demand() {
     let devnet_args = ["--state-archive-capacity", "full", "--block-generation-on", "demand"];
     let devnet = BackgroundDevnet::spawn_with_additional_args(&devnet_args).await.unwrap();
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
+    let (signer, account_address) = devnet.get_first_predeployed_account_credentials().await;
     let predeployed_account = Arc::new(SingleOwnerAccount::new(
         devnet.clone_provider(),
         signer.clone(),
@@ -166,7 +166,7 @@ async fn test_getting_class_after_block_abortion() {
     let devnet_args = ["--state-archive-capacity", "full"];
     let devnet = BackgroundDevnet::spawn_with_additional_args(&devnet_args).await.unwrap();
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
+    let (signer, account_address) = devnet.get_first_predeployed_account_credentials().await;
     let predeployed_account = Arc::new(SingleOwnerAccount::new(
         devnet.clone_provider(),
         signer.clone(),
@@ -232,7 +232,7 @@ async fn getting_compiled_casm_for_cairo0_or_non_existing_hash_should_return_cla
         .await
         .expect("Could not start Devnet");
 
-    let (_, account_address) = devnet.get_first_predeployed_account().await;
+    let (_, account_address) = devnet.get_first_predeployed_account_credentials().await;
 
     let block_id = BlockId::Tag(BlockTag::Latest);
 
@@ -257,7 +257,7 @@ async fn getting_compiled_casm_for_cairo_1_should_succeed() {
     let (_, expected_casm_hash) =
         get_flattened_sierra_contract_and_casm_hash(CAIRO_1_ACCOUNT_CONTRACT_SIERRA_PATH);
 
-    let (_, account_address) = devnet.get_first_predeployed_account().await;
+    let (_, account_address) = devnet.get_first_predeployed_account_credentials().await;
 
     let block_id = BlockId::Tag(BlockTag::Latest);
 

--- a/tests/integration/get_class_hash_at.rs
+++ b/tests/integration/get_class_hash_at.rs
@@ -38,10 +38,7 @@ async fn get_class_hash_at_for_undeployed_address() {
 
 #[tokio::test]
 async fn get_class_hash_at_by_block_number() {
-    let devnet =
-        BackgroundDevnet::spawn_with_additional_args(&["--state-archive-capacity", "full"])
-            .await
-            .expect("Could not start Devnet");
+    let devnet = BackgroundDevnet::spawn_forkable_devnet().await.expect("Could not start Devnet");
     let contract_address = Felt::from_hex_unchecked(PREDEPLOYED_ACCOUNT_ADDRESS);
 
     let result =
@@ -51,10 +48,7 @@ async fn get_class_hash_at_by_block_number() {
 
 #[tokio::test]
 async fn get_class_hash_at_by_block_hash() {
-    let devnet =
-        BackgroundDevnet::spawn_with_additional_args(&["--state-archive-capacity", "full"])
-            .await
-            .expect("Could not start Devnet");
+    let devnet = BackgroundDevnet::spawn_forkable_devnet().await.expect("Could not start Devnet");
     let contract_address = Felt::from_hex_unchecked(PREDEPLOYED_ACCOUNT_ADDRESS);
 
     let err = devnet

--- a/tests/integration/get_devnet_status.rs
+++ b/tests/integration/get_devnet_status.rs
@@ -38,7 +38,7 @@ async fn devnet_get_status_after_interaction() {
     );
 
     // Mint tokens to generate a transaction
-    let (_, account_address) = devnet.get_first_predeployed_account().await;
+    let (_, account_address) = devnet.get_first_predeployed_account_credentials().await;
     let mint_amount = 1_000_000u128;
     devnet.mint(account_address, mint_amount).await;
 

--- a/tests/integration/get_events.rs
+++ b/tests/integration/get_events.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use starknet_rs_accounts::{Account, ConnectedAccount, ExecutionEncoding, SingleOwnerAccount};
+use starknet_rs_accounts::{Account, ConnectedAccount};
 use starknet_rs_core::types::{
     BlockId, BlockStatus, BlockTag, Call, EmittedEvent, EventFilter, Felt, StarknetError,
 };
@@ -8,7 +8,7 @@ use starknet_rs_core::utils::{get_selector_from_name, get_udc_deployed_address};
 use starknet_rs_providers::{Provider, ProviderError};
 
 use crate::common::background_devnet::BackgroundDevnet;
-use crate::common::constants::{self, MAINNET_URL, STRK_ERC20_CONTRACT_ADDRESS};
+use crate::common::constants::{MAINNET_URL, STRK_ERC20_CONTRACT_ADDRESS};
 use crate::common::utils::{get_events_contract_artifacts, new_contract_factory};
 
 async fn get_events_follow_continuation_token(
@@ -40,14 +40,7 @@ async fn get_events_follow_continuation_token(
 /// and deploy a contract that emits events. Then the events are fetched: first all in a single
 /// chunk, then in multiple chunks.
 async fn get_events_correct_chunking(devnet: &BackgroundDevnet, block_on_demand: bool) {
-    let (signer, address) = devnet.get_first_predeployed_account().await;
-    let mut predeployed_account = SingleOwnerAccount::new(
-        devnet.clone_provider(),
-        signer,
-        address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let mut predeployed_account = devnet.get_first_predeployed_account_owned().await;
 
     predeployed_account.set_block_id(BlockId::Tag(BlockTag::PreConfirmed));
 
@@ -204,14 +197,7 @@ async fn get_events_errors() {
 #[tokio::test]
 async fn get_events_with_multiple_addresses() {
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
-    let (signer, address) = devnet.get_first_predeployed_account().await;
-    let mut predeployed_account = SingleOwnerAccount::new(
-        devnet.clone_provider(),
-        signer,
-        address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let mut predeployed_account = devnet.get_first_predeployed_account_owned().await;
 
     predeployed_account.set_block_id(BlockId::Tag(BlockTag::PreConfirmed));
 

--- a/tests/integration/get_transaction_by_hash.rs
+++ b/tests/integration/get_transaction_by_hash.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use starknet_rs_accounts::{
-    Account, AccountFactory, ExecutionEncoding, OpenZeppelinAccountFactory, SingleOwnerAccount,
+    Account, AccountFactory, ExecutionEncoding, OpenZeppelinAccountFactory,
 };
 use starknet_rs_core::types::{
     BlockId, BlockTag, Call, Felt, InvokeTransaction, StarknetError, Transaction,
@@ -25,14 +25,8 @@ async fn get_declare_v3_transaction_by_hash_happy_path() {
 
     let (contract_class, casm_hash) = get_simple_contract_artifacts();
 
-    let (signer, address) = devnet.get_first_predeployed_account().await;
-    let mut account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::Legacy,
-    );
+    let mut account =
+        devnet.get_first_predeployed_account_with_encoding(ExecutionEncoding::Legacy).await;
     account.set_block_id(BlockId::Tag(BlockTag::Latest));
 
     let declare_result = account
@@ -80,15 +74,7 @@ async fn get_deploy_account_transaction_by_hash_happy_path() {
 #[tokio::test]
 async fn get_invoke_v3_transaction_by_hash_happy_path() {
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-
-    let account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let account = devnet.get_first_predeployed_account().await;
 
     let invoke_tx_result = account
         .execute_v3(vec![Call {

--- a/tests/integration/get_transaction_receipt_by_hash.rs
+++ b/tests/integration/get_transaction_receipt_by_hash.rs
@@ -1,8 +1,6 @@
 use std::sync::Arc;
 
-use starknet_rs_accounts::{
-    Account, AccountFactory, ExecutionEncoding, OpenZeppelinAccountFactory, SingleOwnerAccount,
-};
+use starknet_rs_accounts::{Account, AccountFactory, OpenZeppelinAccountFactory};
 use starknet_rs_core::types::{
     Call, ExecutionResult, Felt, StarknetError, TransactionFinalityStatus, TransactionReceipt,
 };
@@ -11,7 +9,7 @@ use starknet_rs_providers::{Provider, ProviderError};
 
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::constants::{
-    self, CAIRO_0_ACCOUNT_CONTRACT_HASH, CHAIN_ID, ETH_ERC20_CONTRACT_ADDRESS,
+    CAIRO_0_ACCOUNT_CONTRACT_HASH, CHAIN_ID, ETH_ERC20_CONTRACT_ADDRESS,
     STRK_ERC20_CONTRACT_ADDRESS, UDC_CONTRACT_ADDRESS,
 };
 use crate::common::utils::{
@@ -60,14 +58,7 @@ async fn deploy_account_transaction_receipt() {
 async fn deploy_transaction_receipt() {
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let predeployed_account = Arc::new(SingleOwnerAccount::new(
-        devnet.clone_provider(),
-        signer,
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    ));
+    let predeployed_account = Arc::new(devnet.get_first_predeployed_account_owned().await);
 
     let (cairo_1_contract, casm_class_hash) = get_events_contract_artifacts();
 
@@ -115,7 +106,7 @@ async fn deploy_transaction_receipt() {
                 vec![get_selector_from_name("ContractDeployed").unwrap()]
             );
             assert_eq!(deployment_event.data[0], expected_contract_address);
-            assert_eq!(deployment_event.data[1], account_address);
+            assert_eq!(deployment_event.data[1], predeployed_account.address());
 
             // Assert STRK fee charge event
             let fee_charge_event = receipt
@@ -127,7 +118,7 @@ async fn deploy_transaction_receipt() {
                 fee_charge_event.keys,
                 vec![
                     get_selector_from_name("Transfer").unwrap(),
-                    account_address,
+                    predeployed_account.address(),
                     Felt::from_hex_unchecked("0x1000") // this is sequencer address
                 ]
             );
@@ -140,14 +131,7 @@ async fn deploy_transaction_receipt() {
 async fn invalid_deploy_transaction_receipt() {
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
 
-    let (signer, address) = devnet.get_first_predeployed_account().await;
-    let predeployed_account = Arc::new(SingleOwnerAccount::new(
-        devnet.clone_provider(),
-        signer,
-        address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    ));
+    let predeployed_account = Arc::new(devnet.get_first_predeployed_account_owned().await);
 
     let (cairo_1_contract, casm_class_hash) = get_events_contract_artifacts();
 
@@ -203,14 +187,7 @@ async fn invalid_deploy_transaction_receipt() {
 async fn reverted_invoke_transaction_receipt() {
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let predeployed_account = SingleOwnerAccount::new(
-        devnet.clone_provider(),
-        signer,
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let predeployed_account = devnet.get_first_predeployed_account_owned().await;
 
     let transfer_execution = predeployed_account.execute_v3(vec![Call {
         to: ETH_ERC20_CONTRACT_ADDRESS,

--- a/tests/integration/messaging.rs
+++ b/tests/integration/messaging.rs
@@ -12,9 +12,7 @@ use std::sync::Arc;
 use alloy::hex::FromHex;
 use alloy::primitives::{Address, U256};
 use serde_json::{Value, json};
-use starknet_rs_accounts::{
-    Account, AccountError, ConnectedAccount, ExecutionEncoding, SingleOwnerAccount,
-};
+use starknet_rs_accounts::{Account, AccountError, ConnectedAccount, SingleOwnerAccount};
 use starknet_rs_core::types::{
     BlockId, BlockTag, Call, ExecuteInvocation, ExecutionResult, Felt, FunctionCall,
     InvokeTransactionReceipt, InvokeTransactionResult, L1HandlerTransactionTrace,
@@ -30,7 +28,7 @@ use crate::assert_eq_prop;
 use crate::common::background_anvil::BackgroundAnvil;
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::constants::{
-    CHAIN_ID, DEFAULT_ETH_ACCOUNT_PRIVATE_KEY, L1_HANDLER_SELECTOR, MESSAGING_L1_CONTRACT_ADDRESS,
+    DEFAULT_ETH_ACCOUNT_PRIVATE_KEY, L1_HANDLER_SELECTOR, MESSAGING_L1_CONTRACT_ADDRESS,
     MESSAGING_L2_CONTRACT_ADDRESS, MESSAGING_WHITELISTED_L1_CONTRACT,
 };
 use crate::common::errors::RpcError;
@@ -159,15 +157,7 @@ pub(crate) async fn setup_devnet(
 > {
     let devnet = BackgroundDevnet::spawn_with_additional_args(devnet_args).await?;
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-
-    let account = Arc::new(SingleOwnerAccount::new(
-        devnet.clone_provider(),
-        signer,
-        account_address,
-        CHAIN_ID,
-        ExecutionEncoding::New,
-    ));
+    let account = Arc::new(devnet.get_first_predeployed_account_owned().await);
 
     let contract_address = deploy_l2_msg_contract(account.clone()).await?;
 

--- a/tests/integration/minting.rs
+++ b/tests/integration/minting.rs
@@ -1,12 +1,10 @@
 use anyhow::anyhow;
 use serde_json::json;
-use starknet_rs_accounts::{Account, ExecutionEncoding, SingleOwnerAccount};
+use starknet_rs_accounts::Account;
 use starknet_rs_core::types::Felt;
 
 use crate::common::background_devnet::BackgroundDevnet;
-use crate::common::constants::{
-    CHAIN_ID, PREDEPLOYED_ACCOUNT_ADDRESS, PREDEPLOYED_ACCOUNT_INITIAL_BALANCE,
-};
+use crate::common::constants::{PREDEPLOYED_ACCOUNT_ADDRESS, PREDEPLOYED_ACCOUNT_INITIAL_BALANCE};
 use crate::common::utils::{FeeUnit, get_simple_contract_artifacts};
 use crate::{assert_eq_prop, assert_prop};
 
@@ -116,14 +114,7 @@ async fn execute_v3_transaction_with_strk_token() {
         .await
         .expect("Could not start Devnet");
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let predeployed_account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        account_address,
-        CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let predeployed_account = devnet.get_first_predeployed_account().await;
 
     let (contract_class, casm_hash) = get_simple_contract_artifacts();
     let declare_result = predeployed_account
@@ -134,9 +125,12 @@ async fn execute_v3_transaction_with_strk_token() {
     assert!(declare_result.is_err());
     // 3. mint some FRI to the account
     // Note: FeeUnit::Fri should be used for STRK tokens in this implementation
-    devnet.mint_unit(account_address, 1_000_000_000_000_000_000_000, FeeUnit::Fri).await;
+    devnet
+        .mint_unit(predeployed_account.address(), 1_000_000_000_000_000_000_000, FeeUnit::Fri)
+        .await;
 
-    let fri_balance = devnet.get_balance_latest(&account_address, FeeUnit::Fri).await.unwrap();
+    let fri_balance =
+        devnet.get_balance_latest(&predeployed_account.address(), FeeUnit::Fri).await.unwrap();
     assert!(fri_balance > Felt::ZERO, "FRI balance should be positive after minting");
 
     let declare_result =

--- a/tests/integration/old_state.rs
+++ b/tests/integration/old_state.rs
@@ -19,7 +19,7 @@ use starknet_rs_providers::{Provider, ProviderError};
 
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::constants::{
-    self, CAIRO_1_VERSION_ASSERTER_SIERRA_PATH, CHAIN_ID, ETH_ERC20_CONTRACT_ADDRESS,
+    CAIRO_1_VERSION_ASSERTER_SIERRA_PATH, CHAIN_ID, ETH_ERC20_CONTRACT_ADDRESS,
     UDC_CONTRACT_ADDRESS,
 };
 use crate::common::utils::{
@@ -29,19 +29,8 @@ use crate::common::utils::{
 
 #[tokio::test]
 async fn get_storage_from_an_old_state() {
-    let devnet =
-        BackgroundDevnet::spawn_with_additional_args(&["--state-archive-capacity", "full"])
-            .await
-            .expect("Could not start Devnet");
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-
-    let account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let devnet = BackgroundDevnet::spawn_forkable_devnet().await.expect("Could not start Devnet");
+    let account = devnet.get_first_predeployed_account().await;
 
     devnet.create_block().await.unwrap();
     let BlockHashAndNumber { block_hash, .. } =
@@ -63,7 +52,7 @@ async fn get_storage_from_an_old_state() {
         .await
         .unwrap();
 
-    let storage_address = get_storage_var_address("ERC20_balances", &[account_address]).unwrap();
+    let storage_address = get_storage_var_address("ERC20_balances", &[account.address()]).unwrap();
 
     let latest_balance = devnet
         .json_rpc_client
@@ -93,10 +82,7 @@ async fn get_storage_from_an_old_state() {
 
 #[tokio::test]
 async fn minting_in_multiple_steps_and_getting_balance_at_each_block() {
-    let devnet =
-        BackgroundDevnet::spawn_with_additional_args(&["--state-archive-capacity", "full"])
-            .await
-            .unwrap();
+    let devnet = BackgroundDevnet::spawn_forkable_devnet().await.unwrap();
 
     // create a block if there are no blocks before starting minting
     devnet.create_block().await.unwrap();
@@ -123,13 +109,10 @@ async fn minting_in_multiple_steps_and_getting_balance_at_each_block() {
 /// Fee estimation of invoke tx that reverts must fail; simulating the same tx must produce trace.
 #[tokio::test]
 async fn fee_estimation_and_simulation_of_deployment_at_old_block_should_not_yield_same_error() {
-    let devnet =
-        BackgroundDevnet::spawn_with_additional_args(&["--state-archive-capacity", "full"])
-            .await
-            .unwrap();
+    let devnet = BackgroundDevnet::spawn_forkable_devnet().await.unwrap();
 
     // get account
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
+    let (signer, account_address) = devnet.get_first_predeployed_account_credentials().await;
     let account = Arc::new(SingleOwnerAccount::new(
         devnet.clone_provider(),
         signer.clone(),
@@ -269,7 +252,7 @@ async fn test_getting_class_at_various_blocks() {
     let devnet_args = ["--state-archive-capacity", "full"];
     let devnet = BackgroundDevnet::spawn_with_additional_args(&devnet_args).await.unwrap();
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
+    let (signer, account_address) = devnet.get_first_predeployed_account_credentials().await;
     let predeployed_account = Arc::new(SingleOwnerAccount::new(
         devnet.clone_provider(),
         signer.clone(),
@@ -326,12 +309,9 @@ async fn test_getting_class_at_various_blocks() {
 
 #[tokio::test]
 async fn test_nonce_retrieval_for_an_old_state() {
-    let devnet =
-        BackgroundDevnet::spawn_with_additional_args(&["--state-archive-capacity", "full"])
-            .await
-            .unwrap();
+    let devnet = BackgroundDevnet::spawn_forkable_devnet().await.unwrap();
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
+    let (signer, account_address) = devnet.get_first_predeployed_account_credentials().await;
     let account = Arc::new(SingleOwnerAccount::new(
         devnet.clone_provider(),
         signer.clone(),
@@ -380,19 +360,8 @@ async fn test_nonce_retrieval_for_an_old_state() {
 
 #[tokio::test]
 async fn get_storage_with_response_flags() {
-    let devnet =
-        BackgroundDevnet::spawn_with_additional_args(&["--state-archive-capacity", "full"])
-            .await
-            .expect("Could not start Devnet");
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-
-    let account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let devnet = BackgroundDevnet::spawn_forkable_devnet().await.expect("Could not start Devnet");
+    let account = devnet.get_first_predeployed_account().await;
 
     let recipient = Felt::ONE;
     let flags: Option<&[StorageResponseFlag]> =

--- a/tests/integration/prove_transaction.rs
+++ b/tests/integration/prove_transaction.rs
@@ -20,20 +20,13 @@ fn transfer_call(recipient: Felt, amount: Felt) -> Call {
 #[tokio::test]
 async fn prove_transaction_endpoint_returns_proof_and_proof_facts() {
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let mut account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let mut account = devnet.get_first_predeployed_account().await;
     account.set_block_id(BlockId::Tag(BlockTag::Latest));
 
     let calls = vec![transfer_call(Felt::ONE, Felt::from(1000u64))];
     let nonce = devnet
         .json_rpc_client
-        .get_nonce(BlockId::Tag(BlockTag::Latest), account_address)
+        .get_nonce(BlockId::Tag(BlockTag::Latest), account.address())
         .await
         .unwrap();
 
@@ -66,20 +59,13 @@ async fn prove_transaction_endpoint_returns_proof_and_proof_facts() {
 #[tokio::test]
 async fn invoke_with_valid_proof_is_accepted() {
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let mut account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let mut account = devnet.get_first_predeployed_account().await;
     account.set_block_id(BlockId::Tag(BlockTag::Latest));
 
     let tx_calls = vec![transfer_call(Felt::ONE, Felt::from(1000u64))];
     let tx_nonce = devnet
         .json_rpc_client
-        .get_nonce(BlockId::Tag(BlockTag::Latest), account_address)
+        .get_nonce(BlockId::Tag(BlockTag::Latest), account.address())
         .await
         .unwrap();
 
@@ -152,20 +138,13 @@ async fn invoke_with_valid_proof_is_accepted() {
 #[tokio::test]
 async fn invoke_with_wrong_proof_is_rejected() {
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let mut account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let mut account = devnet.get_first_predeployed_account().await;
     account.set_block_id(BlockId::Tag(BlockTag::Latest));
 
     let tx_calls = vec![transfer_call(Felt::ONE, Felt::from(1000u64))];
     let tx_nonce = devnet
         .json_rpc_client
-        .get_nonce(BlockId::Tag(BlockTag::Latest), account_address)
+        .get_nonce(BlockId::Tag(BlockTag::Latest), account.address())
         .await
         .unwrap();
 
@@ -243,14 +222,7 @@ async fn invoke_with_wrong_proof_is_rejected() {
 async fn invoke_without_proof_in_devnet_mode_is_accepted() {
     // In devnet proof mode (default), transactions without proof fields should still be accepted
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let mut account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let mut account = devnet.get_first_predeployed_account().await;
     account.set_block_id(BlockId::Tag(BlockTag::Latest));
 
     let calls = vec![transfer_call(Felt::ONE, Felt::from(1000u64))];
@@ -263,20 +235,13 @@ async fn invoke_without_proof_in_devnet_mode_is_accepted() {
 async fn invoke_with_proof_only_and_no_proof_facts_is_rejected() {
     // Sending proof without proof_facts should fail
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let mut account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let mut account = devnet.get_first_predeployed_account().await;
     account.set_block_id(BlockId::Tag(BlockTag::Latest));
 
     let tx_calls = vec![transfer_call(Felt::ONE, Felt::from(1000u64))];
     let tx_nonce = devnet
         .json_rpc_client
-        .get_nonce(BlockId::Tag(BlockTag::Latest), account_address)
+        .get_nonce(BlockId::Tag(BlockTag::Latest), account.address())
         .await
         .unwrap();
 
@@ -350,20 +315,13 @@ async fn invoke_with_proof_only_and_no_proof_facts_is_rejected() {
 #[tokio::test]
 async fn prove_transaction_is_deterministic() {
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let mut account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let mut account = devnet.get_first_predeployed_account().await;
     account.set_block_id(BlockId::Tag(BlockTag::Latest));
 
     let calls = vec![transfer_call(Felt::ONE, Felt::from(1000u64))];
     let nonce = devnet
         .json_rpc_client
-        .get_nonce(BlockId::Tag(BlockTag::Latest), account_address)
+        .get_nonce(BlockId::Tag(BlockTag::Latest), account.address())
         .await
         .unwrap();
 
@@ -408,20 +366,13 @@ async fn prove_transaction_differs_on_different_block_ids() {
         devnet.create_block().await.unwrap();
     }
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let mut account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let mut account = devnet.get_first_predeployed_account().await;
     account.set_block_id(BlockId::Tag(BlockTag::Latest));
 
     let calls = vec![transfer_call(Felt::ONE, Felt::from(1000u64))];
     let nonce = devnet
         .json_rpc_client
-        .get_nonce(BlockId::Tag(BlockTag::Latest), account_address)
+        .get_nonce(BlockId::Tag(BlockTag::Latest), account.address())
         .await
         .unwrap();
 
@@ -472,14 +423,7 @@ async fn invoke_in_proof_mode_none_accepts_without_proof_or_with_wrong_proof() {
         .await
         .expect("Could not start Devnet in proof-mode none");
 
-    let (none_signer, none_account_address) = devnet_none.get_first_predeployed_account().await;
-    let mut none_account = SingleOwnerAccount::new(
-        &devnet_none.json_rpc_client,
-        none_signer,
-        none_account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let mut none_account = devnet_none.get_first_predeployed_account().await;
     none_account.set_block_id(BlockId::Tag(BlockTag::Latest));
 
     let tx_calls = vec![transfer_call(Felt::ONE, Felt::from(1000u64))];
@@ -498,7 +442,7 @@ async fn invoke_in_proof_mode_none_accepts_without_proof_or_with_wrong_proof() {
 
     let nonce_without_proof = devnet_none
         .json_rpc_client
-        .get_nonce(BlockId::Tag(BlockTag::Latest), none_account_address)
+        .get_nonce(BlockId::Tag(BlockTag::Latest), none_account.address())
         .await
         .unwrap();
     let fees_without_proof = none_account
@@ -530,7 +474,7 @@ async fn invoke_in_proof_mode_none_accepts_without_proof_or_with_wrong_proof() {
 
     let devnet_with_proofs = BackgroundDevnet::spawn().await.expect("Could not start proof devnet");
     let (proof_signer, proof_account_address) =
-        devnet_with_proofs.get_first_predeployed_account().await;
+        devnet_with_proofs.get_first_predeployed_account_credentials().await;
     let mut proof_account = SingleOwnerAccount::new(
         &devnet_with_proofs.json_rpc_client,
         proof_signer,
@@ -577,7 +521,7 @@ async fn invoke_in_proof_mode_none_accepts_without_proof_or_with_wrong_proof() {
 
     let nonce_with_valid_proof = devnet_none
         .json_rpc_client
-        .get_nonce(BlockId::Tag(BlockTag::Latest), none_account_address)
+        .get_nonce(BlockId::Tag(BlockTag::Latest), none_account.address())
         .await
         .unwrap();
     let fees_with_valid_proof = none_account
@@ -613,7 +557,7 @@ async fn invoke_in_proof_mode_none_accepts_without_proof_or_with_wrong_proof() {
 
     let nonce_with_wrong_proof = devnet_none
         .json_rpc_client
-        .get_nonce(BlockId::Tag(BlockTag::Latest), none_account_address)
+        .get_nonce(BlockId::Tag(BlockTag::Latest), none_account.address())
         .await
         .unwrap();
     let wrong_proof =
@@ -658,14 +602,7 @@ async fn invoke_in_proof_mode_none_rejects_wrong_proof_facts() {
         .await
         .expect("Could not start Devnet in proof-mode none");
 
-    let (none_signer, none_account_address) = devnet_none.get_first_predeployed_account().await;
-    let mut none_account = SingleOwnerAccount::new(
-        &devnet_none.json_rpc_client,
-        none_signer,
-        none_account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let mut none_account = devnet_none.get_first_predeployed_account().await;
     none_account.set_block_id(BlockId::Tag(BlockTag::Latest));
 
     // Need enough blocks for block-hash retention buffer
@@ -682,7 +619,7 @@ async fn invoke_in_proof_mode_none_rejects_wrong_proof_facts() {
     let tx_calls = vec![transfer_call(Felt::ONE, Felt::from(1000u64))];
     let nonce = devnet_none
         .json_rpc_client
-        .get_nonce(BlockId::Tag(BlockTag::Latest), none_account_address)
+        .get_nonce(BlockId::Tag(BlockTag::Latest), none_account.address())
         .await
         .unwrap();
 
@@ -719,7 +656,6 @@ async fn invoke_in_proof_mode_none_rejects_wrong_proof_facts() {
 async fn prove_transaction_returns_l2_to_l1_messages_for_withdraw() {
     let (devnet, account, contract_address) =
         setup_devnet(&["--account-class", "cairo1"]).await.unwrap();
-    let account_address = account.address();
 
     // increase_balance for user before withdraw
     let user = Felt::ONE;
@@ -737,7 +673,7 @@ async fn prove_transaction_returns_l2_to_l1_messages_for_withdraw() {
 
     let nonce = devnet
         .json_rpc_client
-        .get_nonce(BlockId::Tag(BlockTag::Latest), account_address)
+        .get_nonce(BlockId::Tag(BlockTag::Latest), account.address())
         .await
         .unwrap();
 
@@ -848,20 +784,13 @@ async fn prove_transaction_returns_l2_to_l1_messages_for_withdraw() {
 #[tokio::test]
 async fn prove_transaction_returns_empty_messages_for_simple_transfer() {
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let mut account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let mut account = devnet.get_first_predeployed_account().await;
     account.set_block_id(BlockId::Tag(BlockTag::Latest));
 
     let calls = vec![transfer_call(Felt::ONE, Felt::from(1000u64))];
     let nonce = devnet
         .json_rpc_client
-        .get_nonce(BlockId::Tag(BlockTag::Latest), account_address)
+        .get_nonce(BlockId::Tag(BlockTag::Latest), account.address())
         .await
         .unwrap();
 
@@ -901,14 +830,7 @@ async fn prove_transaction_returns_empty_messages_for_simple_transfer() {
 #[tokio::test]
 async fn prove_transaction_returns_error_on_execution_failure() {
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let mut account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let mut account = devnet.get_first_predeployed_account().await;
     account.set_block_id(BlockId::Tag(BlockTag::Latest));
 
     // Call a non-existent contract to trigger execution failure
@@ -920,7 +842,7 @@ async fn prove_transaction_returns_error_on_execution_failure() {
 
     let nonce = devnet
         .json_rpc_client
-        .get_nonce(BlockId::Tag(BlockTag::Latest), account_address)
+        .get_nonce(BlockId::Tag(BlockTag::Latest), account.address())
         .await
         .unwrap();
 

--- a/tests/integration/restart.rs
+++ b/tests/integration/restart.rs
@@ -1,16 +1,14 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use starknet_rs_accounts::{
-    Account, AccountFactory, ExecutionEncoding, OpenZeppelinAccountFactory, SingleOwnerAccount,
-};
+use starknet_rs_accounts::{Account, AccountFactory, OpenZeppelinAccountFactory};
 use starknet_rs_core::types::{BlockId, BlockTag, Felt, StarknetError};
 use starknet_rs_core::utils::get_storage_var_address;
 use starknet_rs_providers::{Provider, ProviderError};
 
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::constants::{
-    self, CAIRO_0_ACCOUNT_CONTRACT_HASH, CHAIN_ID, STRK_ERC20_CONTRACT_ADDRESS,
+    CAIRO_0_ACCOUNT_CONTRACT_HASH, CHAIN_ID, STRK_ERC20_CONTRACT_ADDRESS,
 };
 use crate::common::utils::{
     FeeUnit, assert_tx_succeeded_accepted, get_deployable_account_signer,
@@ -136,14 +134,7 @@ async fn assert_gas_price_unaffected_by_restart() {
     let devnet = BackgroundDevnet::spawn_with_additional_args(&devnet_args).await.unwrap();
 
     // get a predeployed account
-    let (signer, address) = devnet.get_first_predeployed_account().await;
-    let predeployed_account = Arc::new(SingleOwnerAccount::new(
-        devnet.clone_provider(),
-        signer,
-        address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    ));
+    let predeployed_account = Arc::new(devnet.get_first_predeployed_account_owned().await);
 
     // get class
     let (contract_artifact, casm_hash) = get_simple_contract_artifacts();
@@ -181,7 +172,7 @@ async fn assert_predeployed_account_is_prefunded_after_restart() {
     .await
     .unwrap();
 
-    let predeployed_account_address = devnet.get_first_predeployed_account().await.1;
+    let predeployed_account_address = devnet.get_first_predeployed_account_credentials().await.1;
 
     let balance_before =
         devnet.get_balance_latest(&predeployed_account_address, FeeUnit::Wei).await.unwrap();

--- a/tests/integration/simulate_transactions.rs
+++ b/tests/integration/simulate_transactions.rs
@@ -22,7 +22,7 @@ use starknet_rs_signers::{LocalWallet, Signer, SigningKey};
 
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::constants::{
-    self, CAIRO_1_ACCOUNT_CONTRACT_SIERRA_HASH, CAIRO_1_CONTRACT_PATH,
+    CAIRO_1_ACCOUNT_CONTRACT_SIERRA_HASH, CAIRO_1_CONTRACT_PATH,
     CAIRO_1_PANICKING_CONTRACT_SIERRA_PATH, CAIRO_1_VERSION_ASSERTER_SIERRA_PATH, CHAIN_ID,
     ETH_ERC20_CONTRACT_ADDRESS, QUERY_VERSION_OFFSET, UDC_CONTRACT_ADDRESS,
 };
@@ -38,7 +38,7 @@ async fn simulate_declare_v3() {
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
 
     // get account
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
+    let (signer, account_address) = devnet.get_first_predeployed_account_credentials().await;
     let account = SingleOwnerAccount::new(
         devnet.clone_provider(),
         signer.clone(),
@@ -239,7 +239,7 @@ async fn simulate_invoke_v3() {
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
 
     // get account
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
+    let (signer, account_address) = devnet.get_first_predeployed_account_credentials().await;
     let account = Arc::new(SingleOwnerAccount::new(
         devnet.clone_provider(),
         signer.clone(),
@@ -365,14 +365,7 @@ async fn using_query_version_if_simulating() {
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
 
     // get account
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer.clone(),
-        account_address,
-        CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let (account, signer) = devnet.get_first_predeployed_account_with_signer().await;
 
     // get class
     let (flattened_contract_artifact, casm_hash) =
@@ -433,14 +426,7 @@ async fn using_query_version_if_simulating() {
 async fn test_simulation_of_panicking_invoke() {
     let devnet = BackgroundDevnet::spawn().await.unwrap();
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer.clone(),
-        account_address,
-        devnet.json_rpc_client.chain_id().await.unwrap(),
-        starknet_rs_accounts::ExecutionEncoding::New,
-    );
+    let account = devnet.get_first_predeployed_account().await;
 
     let (contract_class, casm_hash) =
         get_flattened_sierra_contract_and_casm_hash(CAIRO_1_PANICKING_CONTRACT_SIERRA_PATH);
@@ -499,14 +485,7 @@ async fn simulate_of_multiple_txs_shouldnt_return_an_error_if_invoke_transaction
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start devnet");
 
     // get account
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let mut account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer.clone(),
-        account_address,
-        devnet.json_rpc_client.chain_id().await.unwrap(),
-        ExecutionEncoding::New,
-    );
+    let mut account = devnet.get_first_predeployed_account().await;
 
     account.set_block_id(BlockId::Tag(BlockTag::Latest));
 
@@ -544,7 +523,7 @@ async fn simulate_of_multiple_txs_shouldnt_return_an_error_if_invoke_transaction
             account.block_id(),
             [
                 BroadcastedTransaction::Declare(BroadcastedDeclareTransactionV3 {
-                    sender_address: account_address,
+                    sender_address: account.address(),
                     compiled_class_hash: casm_hash,
                     signature: vec![],
                     nonce: Felt::ZERO,
@@ -559,7 +538,7 @@ async fn simulate_of_multiple_txs_shouldnt_return_an_error_if_invoke_transaction
                 }),
                 BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction {
                     broadcasted_invoke_txn_v3: BroadcastedInvokeTransactionV3 {
-                        sender_address: account_address,
+                        sender_address: account.address(),
                         calldata,
                         signature: vec![],
                         nonce: Felt::ONE,
@@ -598,14 +577,7 @@ async fn simulate_of_multiple_txs_shouldnt_return_an_error_if_invoke_transaction
 async fn simulate_of_multiple_txs_should_return_initial_reads_when_flag_present() {
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start devnet");
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let mut account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer.clone(),
-        account_address,
-        devnet.json_rpc_client.chain_id().await.unwrap(),
-        ExecutionEncoding::New,
-    );
+    let mut account = devnet.get_first_predeployed_account().await;
 
     account.set_block_id(BlockId::Tag(BlockTag::Latest));
 
@@ -633,7 +605,7 @@ async fn simulate_of_multiple_txs_should_return_initial_reads_when_flag_present(
 
     let transactions = [
         BroadcastedTransaction::Declare(BroadcastedDeclareTransactionV3 {
-            sender_address: account_address,
+            sender_address: account.address(),
             compiled_class_hash: casm_hash,
             signature: vec![],
             nonce: Felt::ZERO,
@@ -648,7 +620,7 @@ async fn simulate_of_multiple_txs_should_return_initial_reads_when_flag_present(
         }),
         BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction {
             broadcasted_invoke_txn_v3: BroadcastedInvokeTransactionV3 {
-                sender_address: account_address,
+                sender_address: account.address(),
                 calldata,
                 signature: vec![],
                 nonce: Felt::ONE,
@@ -703,14 +675,7 @@ async fn simulate_of_multiple_txs_should_return_index_of_first_failing_transacti
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start devnet");
 
     // get account
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let mut account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer.clone(),
-        account_address,
-        devnet.json_rpc_client.chain_id().await.unwrap(),
-        ExecutionEncoding::New,
-    );
+    let mut account = devnet.get_first_predeployed_account().await;
 
     account.set_block_id(BlockId::Tag(BlockTag::Latest));
 
@@ -748,7 +713,7 @@ async fn simulate_of_multiple_txs_should_return_index_of_first_failing_transacti
             account.block_id(),
             [
                 BroadcastedTransaction::Declare(BroadcastedDeclareTransactionV3 {
-                    sender_address: account_address,
+                    sender_address: account.address(),
                     compiled_class_hash: casm_hash,
                     signature: vec![],
                     nonce: Felt::ZERO,
@@ -763,7 +728,7 @@ async fn simulate_of_multiple_txs_should_return_index_of_first_failing_transacti
                 }),
                 BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction {
                     broadcasted_invoke_txn_v3: BroadcastedInvokeTransactionV3 {
-                        sender_address: account_address,
+                        sender_address: account.address(),
                         calldata,
                         signature: vec![],
                         nonce: Felt::ONE,
@@ -800,15 +765,7 @@ async fn simulate_with_gas_bounds_exceeding_balance_returns_error_if_charging_no
     let (sierra_artifact, casm_hash) =
         get_flattened_sierra_contract_and_casm_hash(CAIRO_1_PANICKING_CONTRACT_SIERRA_PATH);
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-
-    let mut account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let mut account = devnet.get_first_predeployed_account().await;
     account.set_block_id(BlockId::Tag(BlockTag::Latest));
 
     let gas = 1e11 as u64;
@@ -1020,15 +977,7 @@ async fn simulate_invoke_v3_with_fee_just_below_estimated_should_return_a_trace_
     let (sierra_artifact, casm_hash) =
         get_flattened_sierra_contract_and_casm_hash(CAIRO_1_PANICKING_CONTRACT_SIERRA_PATH);
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-
-    let mut account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let mut account = devnet.get_first_predeployed_account().await;
     account.set_block_id(BlockId::Tag(BlockTag::Latest));
 
     let declare_result =
@@ -1075,15 +1024,7 @@ async fn simulate_invoke_declare_deploy_account_with_either_gas_or_gas_price_set
         .await
         .expect("Could not start Devnet");
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-
-    let account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let account = devnet.get_first_predeployed_account().await;
 
     let call = Call {
         to: ETH_ERC20_CONTRACT_ADDRESS,
@@ -1125,7 +1066,7 @@ async fn simulate_invoke_declare_deploy_account_with_either_gas_or_gas_price_set
 
         let invoke_transaction = BroadcastedInvokeTransaction {
             broadcasted_invoke_txn_v3: BroadcastedInvokeTransactionV3 {
-                sender_address: account_address,
+                sender_address: account.address(),
                 calldata: calldata.clone(),
                 signature: vec![],
                 nonce,
@@ -1161,7 +1102,7 @@ async fn simulate_invoke_declare_deploy_account_with_either_gas_or_gas_price_set
             BroadcastedTransaction::DeployAccount(deploy_account_transaction);
 
         let declare_transaction = BroadcastedDeclareTransactionV3 {
-            sender_address: account_address,
+            sender_address: account.address(),
             compiled_class_hash: casm_hash,
             signature: vec![],
             nonce,
@@ -1219,15 +1160,7 @@ async fn simulate_invoke_v3_with_failing_execution_should_return_a_trace_of_reve
     let (sierra_artifact, casm_hash) =
         get_flattened_sierra_contract_and_casm_hash(CAIRO_1_PANICKING_CONTRACT_SIERRA_PATH);
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-
-    let account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let account = devnet.get_first_predeployed_account().await;
 
     let (_, contract_address) =
         declare_v3_deploy_v3(&account, sierra_artifact, casm_hash, &[]).await.unwrap();

--- a/tests/integration/subscription_to_events.rs
+++ b/tests/integration/subscription_to_events.rs
@@ -44,7 +44,7 @@ async fn receive_event(
 async fn get_single_owner_account(
     devnet: &BackgroundDevnet,
 ) -> SingleOwnerAccount<&JsonRpcClient<HttpTransport>, LocalWallet> {
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
+    let (signer, account_address) = devnet.get_first_predeployed_account_credentials().await;
 
     SingleOwnerAccount::new(
         &devnet.json_rpc_client,
@@ -762,7 +762,7 @@ async fn test_fork_subscription_to_events() {
 
     // Emit additional events on the forked devnet
 
-    let (wallet, address) = origin_devnet.get_first_predeployed_account().await; // to avoid nonce clash
+    let (wallet, address) = origin_devnet.get_first_predeployed_account_credentials().await; // to avoid nonce clash
     let original_account_on_fork = SingleOwnerAccount::new(
         &fork_devnet.json_rpc_client,
         wallet,

--- a/tests/integration/subscription_to_new_tx_receipts.rs
+++ b/tests/integration/subscription_to_new_tx_receipts.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use serde_json::json;
 use starknet_core::constants::CHARGEABLE_ACCOUNT_ADDRESS;
-use starknet_rs_accounts::{ExecutionEncoding, SingleOwnerAccount};
+use starknet_rs_accounts::Account;
 use starknet_rs_core::types::{
     DeclareTransactionReceipt, Felt, InvokeTransactionReceipt, Transaction,
     TransactionFinalityStatus, TransactionReceipt, TransactionReceiptWithBlockInfo,
@@ -11,7 +11,6 @@ use tokio::net::TcpStream;
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async};
 
 use crate::common::background_devnet::BackgroundDevnet;
-use crate::common::constants;
 use crate::common::utils::{
     FeeUnit, SubscriptionId, assert_no_notifications, declare_deploy_simple_contract,
     deploy_oz_account, receive_new_tx, receive_notification, receive_rpc_via_ws,
@@ -180,20 +179,14 @@ async fn should_notify_for_filtered_address() {
     let devnet = BackgroundDevnet::spawn().await.unwrap();
     let (mut ws, _) = connect_async(devnet.ws_url()).await.unwrap();
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
+    let predeployed_account = devnet.get_first_predeployed_account().await;
 
-    let predeployed_account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer.clone(),
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
-
-    let subscription_id =
-        subscribe_new_tx_receipts(&mut ws, json!({ "sender_address": [account_address] }))
-            .await
-            .unwrap();
+    let subscription_id = subscribe_new_tx_receipts(
+        &mut ws,
+        json!({ "sender_address": [predeployed_account.address()] }),
+    )
+    .await
+    .unwrap();
 
     // Send the actual txs
     declare_deploy_simple_contract(&predeployed_account).await.unwrap();
@@ -414,14 +407,7 @@ async fn test_declare_transaction_receipt_deserialization() {
     let subscription_id = subscribe_new_tx_receipts(&mut ws, json!({})).await.unwrap();
 
     // Get a predeployed account to use for declaration
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let predeployed_account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let predeployed_account = devnet.get_first_predeployed_account().await;
 
     // Declare and deploy a contract (this will generate multiple transactions)
     let (_declare_tx_hash, _) = declare_deploy_simple_contract(&predeployed_account).await.unwrap();

--- a/tests/integration/subscription_to_new_txs.rs
+++ b/tests/integration/subscription_to_new_txs.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use serde_json::json;
 use starknet_core::constants::CHARGEABLE_ACCOUNT_ADDRESS;
-use starknet_rs_accounts::{ExecutionEncoding, SingleOwnerAccount};
+use starknet_rs_accounts::Account;
 use starknet_rs_core::types::{
     DeclareTransactionV3, DeployAccountTransaction, Felt, InvokeTransactionV3, Transaction,
     TransactionFinalityStatus,
@@ -10,7 +10,6 @@ use starknet_rs_core::types::{
 use tokio_tungstenite::connect_async;
 
 use crate::common::background_devnet::BackgroundDevnet;
-use crate::common::constants;
 use crate::common::utils::{
     FeeUnit, assert_no_notifications, declare_deploy_simple_contract, deploy_oz_account,
     receive_new_tx, receive_rpc_via_ws, send_dummy_mint_tx, subscribe_new_txs, unsubscribe,
@@ -130,18 +129,12 @@ async fn should_notify_for_filtered_address() {
     let devnet = BackgroundDevnet::spawn().await.unwrap();
     let (mut ws, _) = connect_async(devnet.ws_url()).await.unwrap();
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-
-    let predeployed_account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer.clone(),
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let predeployed_account = devnet.get_first_predeployed_account().await;
 
     let subscription_id =
-        subscribe_new_txs(&mut ws, json!({ "sender_address": [account_address] })).await.unwrap();
+        subscribe_new_txs(&mut ws, json!({ "sender_address": [predeployed_account.address()] }))
+            .await
+            .unwrap();
 
     // Send the actual txs
     let (class_hash, _) = declare_deploy_simple_contract(&predeployed_account).await.unwrap();

--- a/tests/integration/trace.rs
+++ b/tests/integration/trace.rs
@@ -3,9 +3,7 @@ use std::sync::Arc;
 use starknet_core::constants::{
     CAIRO_1_ACCOUNT_CONTRACT_SIERRA_HASH, CHARGEABLE_ACCOUNT_ADDRESS, STRK_ERC20_CONTRACT_ADDRESS,
 };
-use starknet_rs_accounts::{
-    Account, AccountFactory, ExecutionEncoding, OpenZeppelinAccountFactory, SingleOwnerAccount,
-};
+use starknet_rs_accounts::{Account, AccountFactory, OpenZeppelinAccountFactory};
 use starknet_rs_core::types::{
     ConfirmedBlockId, DeployedContractItem, ExecuteInvocation, Felt, InvokeTransactionTrace,
     StarknetError, TransactionTrace,
@@ -100,14 +98,7 @@ async fn get_invoke_trace_block_generation_on_demand() {
 async fn get_declare_trace() {
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let predeployed_account = SingleOwnerAccount::new(
-        devnet.clone_provider(),
-        signer,
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let predeployed_account = devnet.get_first_predeployed_account_owned().await;
 
     let (cairo_1_contract, casm_class_hash) = get_events_contract_artifacts();
 
@@ -130,7 +121,7 @@ async fn get_declare_trace() {
     if let TransactionTrace::Declare(declare_trace) = declare_tx_trace {
         let validate_invocation = declare_trace.validate_invocation.unwrap();
 
-        assert_eq!(validate_invocation.contract_address, account_address);
+        assert_eq!(validate_invocation.contract_address, predeployed_account.address());
         assert_eq!(
             validate_invocation.class_hash,
             Felt::from_hex_unchecked(CAIRO_1_ACCOUNT_CONTRACT_SIERRA_HASH)
@@ -155,14 +146,7 @@ async fn get_declare_trace() {
 async fn test_contract_deployment_trace() {
     let devnet = BackgroundDevnet::spawn().await.unwrap();
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let account = Arc::new(SingleOwnerAccount::new(
-        devnet.clone_provider(),
-        signer,
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    ));
+    let account = Arc::new(devnet.get_first_predeployed_account_owned().await);
 
     let (cairo_1_contract, casm_class_hash) = get_events_contract_artifacts();
 

--- a/tests/integration/transaction_handling.rs
+++ b/tests/integration/transaction_handling.rs
@@ -22,7 +22,7 @@ async fn test_failed_validation_with_expected_message() {
     let devnet = BackgroundDevnet::spawn_with_additional_args(&args).await.unwrap();
 
     // get account
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
+    let (signer, account_address) = devnet.get_first_predeployed_account_credentials().await;
     let account = Arc::new(SingleOwnerAccount::new(
         devnet.clone_provider(),
         signer,
@@ -57,14 +57,7 @@ async fn test_declaration_rejected_if_casm_hash_not_matching() {
     let devnet = BackgroundDevnet::spawn().await.unwrap();
 
     // get account
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let account = Arc::new(SingleOwnerAccount::new(
-        devnet.clone_provider(),
-        signer,
-        account_address,
-        CHAIN_ID,
-        ExecutionEncoding::New,
-    ));
+    let account = Arc::new(devnet.get_first_predeployed_account_owned().await);
 
     let (contract_class, _) = get_simple_contract_artifacts();
     let dummy_casm_hash = Felt::ONE;
@@ -95,14 +88,7 @@ async fn test_declaration_rejected_if_casm_hash_not_matching() {
 async fn test_tx_status_content_of_failed_invoke() {
     let devnet = BackgroundDevnet::spawn().await.unwrap();
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        account_address,
-        CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let account = devnet.get_first_predeployed_account().await;
 
     let (sierra, casm_hash) =
         get_flattened_sierra_contract_and_casm_hash(CAIRO_1_PANICKING_CONTRACT_SIERRA_PATH);

--- a/tests/integration/v3_transactions.rs
+++ b/tests/integration/v3_transactions.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use starknet_rs_accounts::{
     Account, AccountDeploymentV3, AccountError, AccountFactory, ConnectedAccount, DeclarationV3,
-    ExecutionEncoding, ExecutionV3, OpenZeppelinAccountFactory, SingleOwnerAccount,
+    ExecutionV3, OpenZeppelinAccountFactory, SingleOwnerAccount,
 };
 use starknet_rs_core::types::{
     BlockId, BlockTag, Call, ExecutionResult, Felt, FlattenedSierraClass, InvokeTransactionResult,
@@ -57,15 +57,7 @@ async fn declare_deploy_happy_path() {
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
     let (sierra_artifact, casm_hash) = get_simple_contract_artifacts();
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-
-    let mut account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let mut account = devnet.get_first_predeployed_account().await;
     account.set_block_id(BlockId::Tag(BlockTag::Latest));
 
     let declare_transaction =
@@ -118,22 +110,17 @@ async fn declare_deploy_happy_path() {
 async fn declare_from_an_account_with_insufficient_strk_tokens_balance() {
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let account = devnet.get_first_predeployed_account().await;
 
     let (sierra_artifact, casm_hash) = get_simple_contract_artifacts();
     let sierra_artifact = Arc::new(sierra_artifact);
     let declaration = account.declare_v3(sierra_artifact.clone(), casm_hash);
     let estimate_fee = declaration.estimate_fee().await.unwrap();
 
-    let account_strk_balance =
-        devnet.get_balance_by_tag(&account_address, FeeUnit::Fri, BlockTag::Latest).await.unwrap();
+    let account_strk_balance = devnet
+        .get_balance_by_tag(&account.address(), FeeUnit::Fri, BlockTag::Latest)
+        .await
+        .unwrap();
 
     // transfer balance of the account without the amount of fee
     let amount_to_transfer =
@@ -158,8 +145,10 @@ async fn declare_from_an_account_with_insufficient_strk_tokens_balance() {
         .await
         .unwrap();
 
-    let account_strk_balance =
-        devnet.get_balance_by_tag(&account_address, FeeUnit::Fri, BlockTag::Latest).await.unwrap();
+    let account_strk_balance = devnet
+        .get_balance_by_tag(&account.address(), FeeUnit::Fri, BlockTag::Latest)
+        .await
+        .unwrap();
     assert!(Felt::from(estimate_fee.overall_fee) > account_strk_balance);
 
     match declaration.send().await.unwrap_err() {
@@ -174,14 +163,7 @@ async fn declare_from_an_account_with_insufficient_strk_tokens_balance() {
 async fn invoke_with_insufficient_gas_price_and_or_gas_units_should_fail() {
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let account = devnet.get_first_predeployed_account().await;
 
     transaction_with_less_gas_units_and_or_less_gas_price_should_return_error_or_be_accepted_as_reverted(
             Action::Execution(vec![Call {
@@ -228,15 +210,7 @@ async fn deploy_account_with_insufficient_gas_price_and_or_gas_units_should_fail
 async fn redeclaration_has_to_fail() {
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
     let (sierra_artifact, casm_hash) = get_simple_contract_artifacts();
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-
-    let mut account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let mut account = devnet.get_first_predeployed_account().await;
     account.set_block_id(BlockId::Tag(BlockTag::Latest));
 
     let sierra_artifact = Arc::new(sierra_artifact);
@@ -265,15 +239,7 @@ async fn declare_with_insufficient_gas_price_and_or_gas_units_should_fail() {
     let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
     let (sierra_artifact, casm_hash) = get_simple_contract_artifacts();
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-
-    let mut account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let mut account = devnet.get_first_predeployed_account().await;
     account.set_block_id(BlockId::Tag(BlockTag::Latest));
 
     let sierra_artifact = Arc::new(sierra_artifact);
@@ -431,14 +397,7 @@ async fn transaction_with_less_gas_units_and_or_less_gas_price_should_return_err
 async fn test_rejection_of_too_big_class_declaration() {
     let devnet = BackgroundDevnet::spawn().await.unwrap();
 
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer,
-        account_address,
-        devnet.json_rpc_client.chain_id().await.unwrap(),
-        ExecutionEncoding::New,
-    );
+    let account = devnet.get_first_predeployed_account().await;
 
     let (contract_class, casm_hash) =
         get_flattened_sierra_contract_and_casm_hash(TOO_BIG_CONTRACT_SIERRA_PATH);

--- a/tests/integration/websocket.rs
+++ b/tests/integration/websocket.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use futures::{SinkExt, StreamExt};
 use serde_json::{Value, json};
-use starknet_rs_accounts::{Account, ExecutionEncoding, SingleOwnerAccount};
+use starknet_rs_accounts::Account;
 use starknet_rs_core::types::{
     BroadcastedDeclareTransactionV3, DataAvailabilityMode, Felt, Transaction,
 };
@@ -13,7 +13,6 @@ use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async};
 
 use crate::common::background_devnet::BackgroundDevnet;
-use crate::common::constants;
 use crate::common::utils::{
     FeeUnit, LocalFee, UniqueAutoDeletableFile, assert_no_notifications,
     get_simple_contract_artifacts, send_binary_rpc_via_ws, send_ctrl_c_signal_and_wait,
@@ -349,14 +348,7 @@ async fn should_declare_via_ws() {
     let devnet = BackgroundDevnet::spawn().await.unwrap();
 
     // Prepare account
-    let (signer, account_address) = devnet.get_first_predeployed_account().await;
-    let account = SingleOwnerAccount::new(
-        &devnet.json_rpc_client,
-        signer.clone(),
-        account_address,
-        constants::CHAIN_ID,
-        ExecutionEncoding::New,
-    );
+    let (account, signer) = devnet.get_first_predeployed_account_with_signer().await;
 
     // Prepare class
     let (simple_class, casm_hash) = get_simple_contract_artifacts();
@@ -384,7 +376,7 @@ async fn should_declare_via_ws() {
 
     // Send the declaration tx via ws
     let sendable_declaration = BroadcastedDeclareTransactionV3 {
-        sender_address: account_address,
+        sender_address: account.address(),
         compiled_class_hash: casm_hash,
         signature: vec![signature.r, signature.s],
         nonce,


### PR DESCRIPTION
## Usage related changes

None.

## Development related changes

- Add shared helpers for constructing borrowed and owned predeployed accounts, including signer and execution-encoding variants.
- Reuse the existing forkable Devnet startup helper for tests requiring full state archival.
- Replace repeated account initialization across integration tests while preserving explicit setup where chain IDs, signers, encodings, or providers are part of the test.
- Keep `Arc` ownership decisions at individual call sites.
- Update the Foundry toolchain action to v1.9.1 so the integration workflow supports the standalone Rust `foundryup` installer.

Closes #924.

### Validation

- `npm --prefix website ci`
- `./scripts/format.sh`
- `./scripts/verify.sh`
- `./scripts/check_spelling.sh`
- `./scripts/check_unused_deps.sh`
- `./scripts/test_integration.sh`
- `git diff --check`
- `git diff --cached --check`

## Checklist:

- [x] Checked the [contribution guide](https://github.com/starknet-io/starknet-devnet/blob/main/.github/CONTRIBUTING.md) and [agent guide](https://github.com/starknet-io/starknet-devnet/blob/main/AGENTS.md) where applicable
- [x] Applied formatting - `npm --prefix website ci && ./scripts/format.sh`
- [x] No routine validation errors - `./scripts/verify.sh`
- [x] No unused dependencies introduced; Rust manifests are unchanged
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Ran integration tests - `./scripts/test_integration.sh`
- [x] Verified packaged UI assets; `web-ui` is unchanged and `./scripts/verify.sh` confirmed generated assets match
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch; the branch is based directly on the current `origin/main`
    - Once you make the PR reviewable, please avoid force-pushing
- [x] Confirmed documentation updates are not needed because behavior is unchanged
- [x] Linked the resolvable issue with `Closes #924`
- [x] Updated the integration tests and verified the affected tests pass
