### PR TITLE
docs: update retired Starknet.js links

### DIFF
--- a/website/docs/api.md
+++ b/website/docs/api.md
@@ -45,7 +45,7 @@ Connected (press CTRL+C to quit)
 
 To spawn Devnet and interact with it using the [Devnet API](#devnet-api), you can use [`starknet-devnet-js`](https://github.com/starknet-io/starknet-devnet-js/). This can be especially useful in achieving [L1-L2 communication](./postman.md).
 
-To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://www.starknetjs.com/).
+To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://starknet-js.com/).
 
 ## Config API
 

--- a/website/versioned_docs/version-0.3.0/api.md
+++ b/website/versioned_docs/version-0.3.0/api.md
@@ -51,7 +51,7 @@ Connected (press CTRL+C to quit)
 
 To spawn Devnet and interact with it using the [Devnet API](#devnet-api), you can use [`starknet-devnet-js`](https://github.com/starknet-io/starknet-devnet-js/). This can be especially useful in achieving [L1-L2 communication](./postman.md).
 
-To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://www.starknetjs.com/).
+To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://starknet-js.com/).
 
 ## Config API
 

--- a/website/versioned_docs/version-0.4.0/api.md
+++ b/website/versioned_docs/version-0.4.0/api.md
@@ -51,7 +51,7 @@ Connected (press CTRL+C to quit)
 
 To spawn Devnet and interact with it using the [Devnet API](#devnet-api), you can use [`starknet-devnet-js`](https://github.com/starknet-io/starknet-devnet-js/). This can be especially useful in achieving [L1-L2 communication](./postman.md).
 
-To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://www.starknetjs.com/).
+To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://starknet-js.com/).
 
 ## Config API
 

--- a/website/versioned_docs/version-0.4.1/api.md
+++ b/website/versioned_docs/version-0.4.1/api.md
@@ -51,7 +51,7 @@ Connected (press CTRL+C to quit)
 
 To spawn Devnet and interact with it using the [Devnet API](#devnet-api), you can use [`starknet-devnet-js`](https://github.com/starknet-io/starknet-devnet-js/). This can be especially useful in achieving [L1-L2 communication](./postman.md).
 
-To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://www.starknetjs.com/).
+To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://starknet-js.com/).
 
 ## Config API
 

--- a/website/versioned_docs/version-0.4.2/api.md
+++ b/website/versioned_docs/version-0.4.2/api.md
@@ -51,7 +51,7 @@ Connected (press CTRL+C to quit)
 
 To spawn Devnet and interact with it using the [Devnet API](#devnet-api), you can use [`starknet-devnet-js`](https://github.com/starknet-io/starknet-devnet-js/). This can be especially useful in achieving [L1-L2 communication](./postman.md).
 
-To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://www.starknetjs.com/).
+To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://starknet-js.com/).
 
 ## Config API
 

--- a/website/versioned_docs/version-0.4.3/api.md
+++ b/website/versioned_docs/version-0.4.3/api.md
@@ -51,7 +51,7 @@ Connected (press CTRL+C to quit)
 
 To spawn Devnet and interact with it using the [Devnet API](#devnet-api), you can use [`starknet-devnet-js`](https://github.com/starknet-io/starknet-devnet-js/). This can be especially useful in achieving [L1-L2 communication](./postman.md).
 
-To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://www.starknetjs.com/).
+To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://starknet-js.com/).
 
 ## Config API
 

--- a/website/versioned_docs/version-0.5.0/api.md
+++ b/website/versioned_docs/version-0.5.0/api.md
@@ -51,7 +51,7 @@ Connected (press CTRL+C to quit)
 
 To spawn Devnet and interact with it using the [Devnet API](#devnet-api), you can use [`starknet-devnet-js`](https://github.com/starknet-io/starknet-devnet-js/). This can be especially useful in achieving [L1-L2 communication](./postman.md).
 
-To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://www.starknetjs.com/).
+To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://starknet-js.com/).
 
 ## Config API
 

--- a/website/versioned_docs/version-0.5.1/api.md
+++ b/website/versioned_docs/version-0.5.1/api.md
@@ -51,7 +51,7 @@ Connected (press CTRL+C to quit)
 
 To spawn Devnet and interact with it using the [Devnet API](#devnet-api), you can use [`starknet-devnet-js`](https://github.com/starknet-io/starknet-devnet-js/). This can be especially useful in achieving [L1-L2 communication](./postman.md).
 
-To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://www.starknetjs.com/).
+To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://starknet-js.com/).
 
 ## Config API
 

--- a/website/versioned_docs/version-0.6.0/api.md
+++ b/website/versioned_docs/version-0.6.0/api.md
@@ -43,7 +43,7 @@ Connected (press CTRL+C to quit)
 
 To spawn Devnet and interact with it using the [Devnet API](#devnet-api), you can use [`starknet-devnet-js`](https://github.com/starknet-io/starknet-devnet-js/). This can be especially useful in achieving [L1-L2 communication](./postman.md).
 
-To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://www.starknetjs.com/).
+To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://starknet-js.com/).
 
 ## Config API
 

--- a/website/versioned_docs/version-0.6.1/api.md
+++ b/website/versioned_docs/version-0.6.1/api.md
@@ -43,7 +43,7 @@ Connected (press CTRL+C to quit)
 
 To spawn Devnet and interact with it using the [Devnet API](#devnet-api), you can use [`starknet-devnet-js`](https://github.com/starknet-io/starknet-devnet-js/). This can be especially useful in achieving [L1-L2 communication](./postman.md).
 
-To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://www.starknetjs.com/).
+To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://starknet-js.com/).
 
 ## Config API
 

--- a/website/versioned_docs/version-0.7.0/api.md
+++ b/website/versioned_docs/version-0.7.0/api.md
@@ -43,7 +43,7 @@ Connected (press CTRL+C to quit)
 
 To spawn Devnet and interact with it using the [Devnet API](#devnet-api), you can use [`starknet-devnet-js`](https://github.com/starknet-io/starknet-devnet-js/). This can be especially useful in achieving [L1-L2 communication](./postman.md).
 
-To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://www.starknetjs.com/).
+To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://starknet-js.com/).
 
 ## Config API
 

--- a/website/versioned_docs/version-0.7.1/api.md
+++ b/website/versioned_docs/version-0.7.1/api.md
@@ -43,7 +43,7 @@ Connected (press CTRL+C to quit)
 
 To spawn Devnet and interact with it using the [Devnet API](#devnet-api), you can use [`starknet-devnet-js`](https://github.com/starknet-io/starknet-devnet-js/). This can be especially useful in achieving [L1-L2 communication](./postman.md).
 
-To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://www.starknetjs.com/).
+To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://starknet-js.com/).
 
 ## Config API
 

--- a/website/versioned_docs/version-0.7.2/api.md
+++ b/website/versioned_docs/version-0.7.2/api.md
@@ -43,7 +43,7 @@ Connected (press CTRL+C to quit)
 
 To spawn Devnet and interact with it using the [Devnet API](#devnet-api), you can use [`starknet-devnet-js`](https://github.com/starknet-io/starknet-devnet-js/). This can be especially useful in achieving [L1-L2 communication](./postman.md).
 
-To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://www.starknetjs.com/).
+To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://starknet-js.com/).
 
 ## Config API
 

--- a/website/versioned_docs/version-0.8.0/api.md
+++ b/website/versioned_docs/version-0.8.0/api.md
@@ -45,7 +45,7 @@ Connected (press CTRL+C to quit)
 
 To spawn Devnet and interact with it using the [Devnet API](#devnet-api), you can use [`starknet-devnet-js`](https://github.com/starknet-io/starknet-devnet-js/). This can be especially useful in achieving [L1-L2 communication](./postman.md).
 
-To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://www.starknetjs.com/).
+To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://starknet-js.com/).
 
 ## Config API
 

--- a/website/versioned_docs/version-0.8.1/api.md
+++ b/website/versioned_docs/version-0.8.1/api.md
@@ -45,7 +45,7 @@ Connected (press CTRL+C to quit)
 
 To spawn Devnet and interact with it using the [Devnet API](#devnet-api), you can use [`starknet-devnet-js`](https://github.com/starknet-io/starknet-devnet-js/). This can be especially useful in achieving [L1-L2 communication](./postman.md).
 
-To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://www.starknetjs.com/).
+To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://starknet-js.com/).
 
 ## Config API
 

--- a/website/versioned_docs/version-0.8.2/api.md
+++ b/website/versioned_docs/version-0.8.2/api.md
@@ -45,7 +45,7 @@ Connected (press CTRL+C to quit)
 
 To spawn Devnet and interact with it using the [Devnet API](#devnet-api), you can use [`starknet-devnet-js`](https://github.com/starknet-io/starknet-devnet-js/). This can be especially useful in achieving [L1-L2 communication](./postman.md).
 
-To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://www.starknetjs.com/).
+To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://starknet-js.com/).
 
 ## Config API
 

--- a/website/versioned_docs/version-0.9.0/api.md
+++ b/website/versioned_docs/version-0.9.0/api.md
@@ -45,7 +45,7 @@ Connected (press CTRL+C to quit)
 
 To spawn Devnet and interact with it using the [Devnet API](#devnet-api), you can use [`starknet-devnet-js`](https://github.com/starknet-io/starknet-devnet-js/). This can be especially useful in achieving [L1-L2 communication](./postman.md).
 
-To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://www.starknetjs.com/).
+To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://starknet-js.com/).
 
 ## Config API
 

--- a/website/versioned_docs/version-0.9.1/api.md
+++ b/website/versioned_docs/version-0.9.1/api.md
@@ -45,7 +45,7 @@ Connected (press CTRL+C to quit)
 
 To spawn Devnet and interact with it using the [Devnet API](#devnet-api), you can use [`starknet-devnet-js`](https://github.com/starknet-io/starknet-devnet-js/). This can be especially useful in achieving [L1-L2 communication](./postman.md).
 
-To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://www.starknetjs.com/).
+To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://starknet-js.com/).
 
 ## Config API
 

--- a/website/versioned_docs/version-0.9.2/api.md
+++ b/website/versioned_docs/version-0.9.2/api.md
@@ -45,7 +45,7 @@ Connected (press CTRL+C to quit)
 
 To spawn Devnet and interact with it using the [Devnet API](#devnet-api), you can use [`starknet-devnet-js`](https://github.com/starknet-io/starknet-devnet-js/). This can be especially useful in achieving [L1-L2 communication](./postman.md).
 
-To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://www.starknetjs.com/).
+To interact with Devnet using the [Starknet API](#starknet-api), use [starknet.js](https://starknet-js.com/).
 
 ## Config API
 


### PR DESCRIPTION
## Summary
- replace the retired `www.starknetjs.com` host with `starknet-js.com` in the current Devnet API docs
- apply the same correction across all 18 released-version API docs

## Validation
- `git diff --check`
- verified `https://starknet-js.com/` returns HTTP 200

## Not run
- website formatter/build: the local Node runtime aborts during `node --version`; `./scripts/doctor.sh` reports this as an optional-tool warning.