### PR TITLE
fix: match request logging directives exactly

### DIFF
--- a/crates/starknet-devnet/src/cli.rs
+++ b/crates/starknet-devnet/src/cli.rs
@@ -405,8 +405,10 @@ struct RequestResponseLogging {
 impl RequestResponseLogging {
     fn from_rust_log_environment_variable() -> Self {
         let log_env_var = std::env::var(EnvFilter::DEFAULT_ENV).unwrap_or_default().to_lowercase();
-        let log_request = log_env_var.contains(REQUEST_LOG_ENV_VAR);
-        let log_response = log_env_var.contains(RESPONSE_LOG_ENV_VAR);
+        let has_directive =
+            |directive: &str| log_env_var.split(',').map(str::trim).any(|item| item == directive);
+        let log_request = has_directive(REQUEST_LOG_ENV_VAR);
+        let log_response = has_directive(RESPONSE_LOG_ENV_VAR);
 
         Self { log_request, log_response }
     }
@@ -633,6 +635,9 @@ mod tests {
             ("REQUEST,RESPONSE", true, true),
             ("REQUEST", true, false),
             ("RESPONSE", false, true),
+            (" request , response ", true, true),
+            ("request_handler=trace,response_cache=debug", false, false),
+            ("starknet_devnet::request=trace", false, false),
         ] {
             unsafe {
                 std::env::set_var(EnvFilter::DEFAULT_ENV, environment_variable);


### PR DESCRIPTION
## Usage related changes

The special `REQUEST` and `RESPONSE` `RUST_LOG` directives are now matched as standalone comma-separated directives.

Previously, normal tracing targets such as `request_handler=trace`, `response_cache=debug`, or `starknet_devnet::request=trace` unintentionally enabled full HTTP request or response body logging because the parser used substring matching.

The matching remains case-insensitive and tolerates whitespace around standalone directives.

## Development related changes

Updated `RequestResponseLogging::from_rust_log_environment_variable` to parse directives exactly, consistent with the existing tracing-filter handling. Added regression cases for valid whitespace, target names containing `request` or `response`, and qualified tracing targets.

## Validation

- failure-before-fix parser witness reproduced the false positives
- focused fixed-parser regression matrix: 4/4 passed
- pinned Rust formatter: passed
- `git diff --check`: passed
- the focused crate test cannot execute on this Windows host because the existing binary imports Unix-only `tokio::net::UnixStream`; this is unrelated to the changed parser

## Checklist

- [x] Checked the contribution guide and agent guide
- [x] Applied formatting to the changed Rust file
- [ ] No routine validation errors — full verification is blocked locally by the existing Windows/UnixStream build issue
- [x] No unused dependencies — no manifests changed
- [ ] No spelling errors — the repository spelling script was not run locally
- [ ] Ran integration tests — not run locally
- [x] Regenerated packaged UI assets — not applicable; no UI changes
- [x] Performed code self-review
- [x] Rebased to the latest target branch before opening
- [x] Updated the docs if needed — no documentation change is required
- [ ] Linked issues — no matching open issue exists
- [ ] Updated the tests if needed; all passing — regressions pass, but the full crate test is blocked as documented above